### PR TITLE
  feat: add column filter for large datasets with many columns

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ const App: React.FC = () => {
   const [brushSelection, setBrushSelection] = useState<BrushSelection | null>(null);
   const [filterMode, setFilterMode] = useState<FilterMode>('highlight');
   const [showHistograms, setShowHistograms] = useState<boolean>(true);
+  const [columnFilter, setColumnFilter] = useState<string>('');
   const [tooltip, setTooltip] = useState<{ visible: boolean; content: string; x: number; y: number }>({
     visible: false,
     content: '',
@@ -101,6 +102,18 @@ const App: React.FC = () => {
     setTooltip(prev => ({ ...prev, visible: false }));
   };
 
+  const handleColumnFilterChange = (filter: string) => {
+    setColumnFilter(filter);
+
+    // Update column visibility based on filter
+    setColumns(prevColumns => {
+      return prevColumns.map(col => ({
+        ...col,
+        visible: filter === '' || col.name.toLowerCase().includes(filter.toLowerCase())
+      }));
+    });
+  };
+
   if (!columns.length) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 text-gray-700">
@@ -142,6 +155,8 @@ const App: React.FC = () => {
               showHistograms={showHistograms}
               setShowHistograms={setShowHistograms}
               labelColumn={labelColumn}
+              columnFilter={columnFilter}
+              onColumnFilterChange={handleColumnFilterChange}
             />
           </aside>
           <main className="flex-1 p-4 bg-gray-100 overflow-auto">

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -12,6 +12,8 @@ interface ControlPanelProps {
   showHistograms: boolean;
   setShowHistograms: (show: boolean) => void;
   labelColumn: string | null;
+  columnFilter: string;
+  onColumnFilterChange: (filter: string) => void;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({
@@ -23,6 +25,8 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   showHistograms,
   setShowHistograms,
   labelColumn,
+  columnFilter,
+  onColumnFilterChange,
 }) => {
   
   const handleDownloadSVG = () => {
@@ -56,6 +60,28 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
                 Using column <span className="font-semibold">"{labelColumn}"</span> for point labels.
             </p>
         )}
+      </div>
+
+      <div>
+        <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Column Filter</h2>
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="columnFilter" className="block text-sm font-medium text-gray-700 mb-1">Filter Columns</label>
+            <input
+              id="columnFilter"
+              type="text"
+              value={columnFilter}
+              onChange={(e) => onColumnFilterChange(e.target.value)}
+              placeholder="Type to filter columns (e.g. mac1, n_snps)"
+              className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-brand-secondary focus:border-brand-secondary text-sm"
+            />
+            {columnFilter && (
+              <p className="text-xs text-gray-500 mt-1">
+                Showing {columns.filter(col => col.visible).length} of {columns.length} columns
+              </p>
+            )}
+          </div>
+        </div>
       </div>
 
       <div>


### PR DESCRIPTION
  - Add text input filter in ControlPanel sidebar
  - Implement case-insensitive substring matching for column names
  - Real-time column visibility updates as user types
  - Display filtered column count (X of Y columns)
  - Perfect for datasets with 30+ columns and similar naming patterns

  🤖 Generated with [Claude Code](https://claude.ai/code)

  Co-Authored-By: Claude <noreply@anthropic.com>

**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
