### PR TITLE
Fix selection hash collisions and add cache tests

### DIFF
--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -23,12 +23,7 @@ export const computeSelectedStateHash = (selectedIds: Set<number>): string => {
     return '0:';
   }
 
-  const sortedIds = new Array<number>(selectedIds.size);
-  let index = 0;
-  selectedIds.forEach(id => {
-    sortedIds[index++] = id;
-  });
-  sortedIds.sort((a, b) => a - b);
+  const sortedIds = Array.from(selectedIds).sort((a, b) => a - b);
 
   return `${sortedIds.length}:${sortedIds.join(',')}`;
 };

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -273,7 +273,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     return `${dataLength}-${selectedSize}-${firstDataId}`;
   }, [data.length, selectedIds.size, data]);
 
-  const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds, selectedIds.size]);
+  const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds]);
 
   // Drag optimization callbacks
   const handleDragStart = useCallback(() => {

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -18,6 +18,21 @@ interface ScatterPlotMatrixProps {
   onPointLeave: () => void;
 }
 
+export const computeSelectedStateHash = (selectedIds: Set<number>): string => {
+  if (selectedIds.size === 0) {
+    return '0:';
+  }
+
+  const sortedIds = new Array<number>(selectedIds.size);
+  let index = 0;
+  selectedIds.forEach(id => {
+    sortedIds[index++] = id;
+  });
+  sortedIds.sort((a, b) => a - b);
+
+  return `${sortedIds.length}:${sortedIds.join(',')}`;
+};
+
 const DraggableHeader: React.FC<{
   name: string,
   index: number,
@@ -263,9 +278,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     return `${dataLength}-${selectedSize}-${firstDataId}`;
   }, [data.length, selectedIds.size, data]);
 
-  const selectedStateHash = useMemo(() => {
-    return `${selectedIds.size}-${Array.from(selectedIds).slice(0, 5).join(',')}`;
-  }, [selectedIds]);
+  const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds, selectedIds.size]);
 
   // Drag optimization callbacks
   const handleDragStart = useCallback(() => {

--- a/src/test/selectionCache.test.ts
+++ b/src/test/selectionCache.test.ts
@@ -17,8 +17,7 @@ describe('selected state cache key stability', () => {
 
   it('produces stable cache keys for identical selections regardless of order', () => {
     const selectionA = new Set([7, 3, 11, 5]);
-    const selectionB = new Set<number>();
-    [5, 11, 3, 7].forEach(id => selectionB.add(id));
+    const selectionB = new Set([5, 11, 3, 7]);
 
     expect(buildCacheKey(selectionA)).toEqual(buildCacheKey(selectionB));
   });

--- a/src/test/selectionCache.test.ts
+++ b/src/test/selectionCache.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { computeSelectedStateHash } from '../../components/ScatterPlotMatrix';
+
+const buildCacheKey = (selectedIds: Set<number>) =>
+  `x-y-linear-linear-data-${computeSelectedStateHash(selectedIds)}-highlight`;
+
+describe('selected state cache key stability', () => {
+  it('updates cache keys when selection membership changes', () => {
+    const initialSelection = new Set([1, 2, 3, 4, 5, 6]);
+    const updatedSelection = new Set([1, 2, 3, 4, 5, 42]);
+
+    const initialKey = buildCacheKey(initialSelection);
+    const updatedKey = buildCacheKey(updatedSelection);
+
+    expect(initialKey).not.toEqual(updatedKey);
+  });
+
+  it('produces stable cache keys for identical selections regardless of order', () => {
+    const selectionA = new Set([7, 3, 11, 5]);
+    const selectionB = new Set<number>();
+    [5, 11, 3, 7].forEach(id => selectionB.add(id));
+
+    expect(buildCacheKey(selectionA)).toEqual(buildCacheKey(selectionB));
+  });
+});


### PR DESCRIPTION
## Summary
- compute a deterministic selection hash that includes every selected id for cache keys
- add unit coverage to ensure cache keys change when selection membership changes and remain stable otherwise

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dfe40d3f1c832787af4f5f6877eed2