### PR TITLE
Fix typo in scatter plot matrix comment

### DIFF
--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -285,7 +285,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     svg.selectAll("*").remove(); // Clear previous render
 
     const createScale = (c: Column, range: [number, number]) => {
-      // Force coersion to number and filter out non-finite values
+      // Force coercion to number and filter out non-finite values
       const values = data.map(d => +d[c.name]).filter(isFinite);
       const extent = d3.extent(values);
 


### PR DESCRIPTION
## Summary
- correct the spelling of "coercion" in a scatter plot matrix comment

------
https://chatgpt.com/codex/tasks/task_e_68dfe42dcfb88327b90949c58b6d76fa