### PR TITLE
Optimize scatter plot matrix rendering performance

### DIFF
--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -71,11 +71,10 @@ const DraggableHeader: React.FC<{
     <div
       ref={ref}
       style={{ opacity: isDragging ? 0.5 : 1 }}
-      className={`w-full h-full flex items-center justify-center border rounded cursor-move select-none ${
-        isDragging ? 'border-brand-secondary bg-gray-100' :
+      className={`w-full h-full flex items-center justify-center border rounded cursor-move select-none ${isDragging ? 'border-brand-secondary bg-gray-100' :
         isOver ? 'border-brand-primary bg-brand-primary/10' :
-        'border-gray-300'
-      }`}
+          'border-gray-300'
+        }`}
     >
       {isDragging ? (
         <span className="font-bold text-gray-400 p-2 text-center break-all">Moving...</span>
@@ -103,23 +102,19 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 }) => {
   const ref = useRef<SVGSVGElement>(null);
   const canvasContainerRef = useRef<HTMLDivElement>(null);
-  const canvasCacheRef = useRef<Map<string, HTMLCanvasElement>>(new Map());
   const canvasElementsRef = useRef<Map<string, HTMLCanvasElement>>(new Map());
-  const imageDataCacheRef = useRef<Map<string, string>>(new Map()); // Store image URLs
+  const canvasRenderKeyRef = useRef<Map<string, string>>(new Map());
   const isDraggingRef = useRef(false);
   const size = 150;
   const padding = 20;
 
-  const { visibleColumns, visibleIndexToOriginalIndex, originalIndexToVisibleIndex } = useMemo(
+  const { visibleColumns, visibleIndexToOriginalIndex } = useMemo(
     () => mapVisibleColumns(columns),
     [columns]
   );
-  
+
   const n = visibleColumns.length;
   const plotSize = showHistograms ? size * (n + 1) : size * n;
-  
-  // Create a dependency string for scales of visible columns
-  const scaleDependency = useMemo(() => visibleColumns.map(c => c.scale).join(','), [visibleColumns]);
 
   const selectedIds = useMemo(() => {
     return brushSelection?.selectedIds || new Set<number>();
@@ -137,8 +132,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 
       const screenX = xScale(x);
       const screenY = yScale(y);
-      const gridX = Math.floor((screenX - padding/2) / (size - padding) * gridSize);
-      const gridY = Math.floor((screenY - padding/2) / (size - padding) * gridSize);
+      const gridX = Math.floor((screenX - padding / 2) / (size - padding) * gridSize);
+      const gridY = Math.floor((screenY - padding / 2) / (size - padding) * gridSize);
 
       if (gridX >= 0 && gridX < gridSize && gridY >= 0 && gridY < gridSize) {
         grid[gridX][gridY].push(d);
@@ -153,10 +148,10 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     const gridSize = 20;
     const selectedIds = new Set<number>();
 
-    const startGridX = Math.max(0, Math.floor((x0 - padding/2) / (size - padding) * gridSize));
-    const endGridX = Math.min(gridSize - 1, Math.floor((x1 - padding/2) / (size - padding) * gridSize));
-    const startGridY = Math.max(0, Math.floor((y0 - padding/2) / (size - padding) * gridSize));
-    const endGridY = Math.min(gridSize - 1, Math.floor((y1 - padding/2) / (size - padding) * gridSize));
+    const startGridX = Math.max(0, Math.floor((x0 - padding / 2) / (size - padding) * gridSize));
+    const endGridX = Math.min(gridSize - 1, Math.floor((x1 - padding / 2) / (size - padding) * gridSize));
+    const startGridY = Math.max(0, Math.floor((y0 - padding / 2) / (size - padding) * gridSize));
+    const endGridY = Math.min(gridSize - 1, Math.floor((y1 - padding / 2) / (size - padding) * gridSize));
 
     for (let gx = startGridX; gx <= endGridX; gx++) {
       for (let gy = startGridY; gy <= endGridY; gy++) {
@@ -228,52 +223,105 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     ctx.globalAlpha = 1;
   }, [size]);
 
-  // Convert canvas to cached image data URL
-  const cacheCanvasAsImage = useCallback((canvas: HTMLCanvasElement, key: string) => {
-    try {
-      const imageUrl = canvas.toDataURL('image/png');
-      imageDataCacheRef.current.set(key, imageUrl);
-    } catch (e) {
-      console.warn('Failed to cache canvas as image:', e);
-    }
-  }, []);
-
-  // Create image element from cached data
-  const createImageFromCache = useCallback((key: string, left: number, top: number): HTMLImageElement | null => {
-    const imageUrl = imageDataCacheRef.current.get(key);
-    if (!imageUrl) return null;
-
-    const img = document.createElement('img');
-    img.src = imageUrl;
-    img.style.position = 'absolute';
-    img.style.left = `${left}px`;
-    img.style.top = `${top}px`;
-    img.style.pointerEvents = 'none';
-    img.width = size;
-    img.height = size;
-    return img;
-  }, [size]);
-
-
   const { filteredData, selectedData } = useMemo(
     () => filterData(data, selectedIds, filterMode),
     [data, selectedIds, filterMode]
   );
 
-  // Create stable cache key based on data characteristics, not positions
-  const createCacheKey = useCallback((colX: string, colY: string, scaleX: string, scaleY: string, dataHash: string, selectedHash: string, filterMode: FilterMode) => {
-    return `${colX}-${colY}-${scaleX}-${scaleY}-${dataHash}-${selectedHash}-${filterMode}`;
-  }, []);
-
-  // Simple hash for data state
   const dataStateHash = useMemo(() => {
-    const dataLength = data.length;
-    const selectedSize = selectedIds.size;
-    const firstDataId = data[0]?.__id ?? 0;
-    return `${dataLength}-${selectedSize}-${firstDataId}`;
-  }, [data.length, selectedIds.size, data]);
+    if (data.length === 0) return 'empty';
+    const firstId = data[0]?.__id ?? 0;
+    const lastId = data[data.length - 1]?.__id ?? 0;
+    return `${data.length}-${firstId}-${lastId}`;
+  }, [data]);
 
-  const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds]);
+  const selectedStateHash = useMemo(() => {
+    if (selectedIds.size === 0) return 'none';
+    let index = 0;
+    let sample = '';
+    for (const id of selectedIds) {
+      if (index < 10) {
+        sample += index === 0 ? `${id}` : `,${id}`;
+      } else {
+        break;
+      }
+      index += 1;
+    }
+    return `${selectedIds.size}-${sample}`;
+  }, [selectedIds]);
+
+  const columnStats = useMemo(() => {
+    const stats = new Map<string, { min: number; max: number; minPositive: number }>();
+    visibleColumns.forEach(col => {
+      stats.set(col.name, { min: Infinity, max: -Infinity, minPositive: Infinity });
+    });
+
+    if (visibleColumns.length === 0) {
+      return stats;
+    }
+
+    for (const row of data) {
+      for (const col of visibleColumns) {
+        const value = +row[col.name];
+        if (!isFinite(value)) continue;
+        const columnStat = stats.get(col.name);
+        if (!columnStat) continue;
+        if (value < columnStat.min) columnStat.min = value;
+        if (value > columnStat.max) columnStat.max = value;
+        if (value > 0 && value < columnStat.minPositive) columnStat.minPositive = value;
+      }
+    }
+
+    visibleColumns.forEach(col => {
+      const stat = stats.get(col.name);
+      if (!stat) return;
+      if (!isFinite(stat.min)) stat.min = 0;
+      if (!isFinite(stat.max)) stat.max = 1;
+      if (!isFinite(stat.minPositive)) stat.minPositive = Math.max(1e-9, stat.max);
+      if (stat.min === stat.max) {
+        stat.min = stat.min - 1;
+        stat.max = stat.max + 1;
+      }
+    });
+
+    return stats;
+  }, [data, visibleColumns]);
+
+  const createScale = useCallback(
+    (column: Column, range: [number, number]) => {
+      const stat = columnStats.get(column.name);
+      const defaultDomain: [number, number] = [0, 1];
+
+      if (!stat) {
+        return d3.scaleLinear().domain(defaultDomain).range(range);
+      }
+
+      if (column.scale === 'log') {
+        const start = Math.max(1e-9, Math.min(stat.minPositive, stat.max));
+        let end = Math.max(1e-9, stat.max);
+        if (start >= end) {
+          end = start * 10;
+        }
+        return d3.scaleLog().domain([start, end]).range(range);
+      }
+
+      return d3.scaleLinear().domain([stat.min, stat.max]).range(range);
+    },
+    [columnStats]
+  );
+
+  const xScales = useMemo(
+    () => visibleColumns.map(col => createScale(col, [padding / 2, size - padding / 2])),
+    [visibleColumns, createScale, padding, size]
+  );
+
+  const yScales = useMemo(
+    () => visibleColumns.map(col => createScale(col, [size - padding / 2, padding / 2])),
+    [visibleColumns, createScale, padding, size]
+  );
+
+  const cellCoordinates = useMemo(() => d3.cross(d3.range(n), d3.range(n)), [n]);
+  const headerIndices = useMemo(() => d3.range(n), [n]);
 
   // Drag optimization callbacks
   const handleDragStart = useCallback(() => {
@@ -293,7 +341,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     svg.selectAll("*").remove(); // Clear previous render
 
     const createScale = (c: Column, range: [number, number]) => {
-      // Force coercion to number and filter out non-finite values
+      // Force coersion to number and filter out non-finite values
       const values = data.map(d => +d[c.name]).filter(isFinite);
       const extent = d3.extent(values);
 
@@ -311,7 +359,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         domain = [start, end];
         return d3.scaleLog().domain(domain).range(range);
       }
-      
+
       if (domain[0] === domain[1]) {
         domain = [domain[0] - 1, domain[1] + 1];
       }
@@ -321,12 +369,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 
     if (n === 0) return; // Don't render if no columns are visible
 
-    const xScales = visibleColumns.map(c => createScale(c, [padding / 2, size - padding / 2]));
-    const yScales = visibleColumns.map(c => createScale(c, [size - padding / 2, padding / 2]));
-    
     const cell = svg.append("g")
       .selectAll("g")
-      .data(d3.cross(d3.range(n), d3.range(n)))
+      .data(cellCoordinates)
       .join("g")
       .attr("transform", ([i, j]) => `translate(${i * size},${j * size})`)
       .attr("data-index-i", ([i, _]) => i)
@@ -335,32 +380,32 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     const brushableCells = cell.filter(([i, j]) => i !== j);
     let histCellsBottom: d3.Selection<SVGGElement, number, SVGGElement, unknown> | null = null;
     let histCellsRight: d3.Selection<SVGGElement, number, SVGGElement, unknown> | null = null;
-    
-    const brush = d3.brush().extent([[padding/2, padding/2], [size-padding/2, size-padding/2]]);
-    const brushX = d3.brushX().extent([[padding/2, padding/2], [size - padding/2, size - padding/2]]);
-    const brushY = d3.brushY().extent([[padding/2, padding/2], [size - padding/2, size - padding/2]]);
+
+    const brush = d3.brush().extent([[padding / 2, padding / 2], [size - padding / 2, size - padding / 2]]);
+    const brushX = d3.brushX().extent([[padding / 2, padding / 2], [size - padding / 2, size - padding / 2]]);
+    const brushY = d3.brushY().extent([[padding / 2, padding / 2], [size - padding / 2, size - padding / 2]]);
 
     brush
-      .on("end", function(event) {
+      .on("end", function (event) {
         if (!event.sourceEvent) return; // Ignore programmatic brushes
 
         const parentNode = this.parentNode as Element;
         if (!parentNode) return;
 
         if (!event.selection) {
-            onBrush(null);
-            return;
+          onBrush(null);
+          return;
         }
 
         const i_visible = parseInt(d3.select(parentNode).attr("data-index-i")!, 10);
         const j_visible = parseInt(d3.select(parentNode).attr("data-index-j")!, 10);
         const i_original = visibleIndexToOriginalIndex.get(i_visible);
         const j_original = visibleIndexToOriginalIndex.get(j_visible);
-        
+
         if (i_original === undefined || j_original === undefined) return;
 
         const [[x0, y0], [x1, y1]] = event.selection;
-        
+
         const colX = columns[i_original];
         const colY = columns[j_original];
         if (!colX || !colY) return;
@@ -369,92 +414,82 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         const grid = createSpatialGrid(data, xScales[i_visible], yScales[j_visible], colX.name, colY.name);
         const newSelectedIds = getPointsInBrush(grid, xScales[i_visible], yScales[j_visible], x0, y0, x1, y1, colX.name, colY.name);
         onBrush({ indexX: i_original, indexY: j_original, x0, y0, x1, y1, selectedIds: newSelectedIds });
-    });
+      });
 
     brushableCells.call(brush);
-    
+
     // Create canvas elements for point rendering
     if (!canvasContainerRef.current) return;
 
-    if (isDraggingRef.current) {
-      // During drag, use cached images for better performance
-      canvasContainerRef.current.innerHTML = '';
+    const activeCanvases = new Set<string>();
+    const container = canvasContainerRef.current;
 
-      brushableCells.each(function ([i, j]) {
-        const i_original = visibleIndexToOriginalIndex.get(i);
-        const j_original = visibleIndexToOriginalIndex.get(j);
-        if (i_original === undefined || j_original === undefined) return;
+    brushableCells.each(function ([i, j]) {
+      const i_original = visibleIndexToOriginalIndex.get(i);
+      const j_original = visibleIndexToOriginalIndex.get(j);
+      if (i_original === undefined || j_original === undefined) return;
 
-        const colX = columns[i_original];
-        const colY = columns[j_original];
-        if (!colX || !colY) return;
+      const colX = columns[i_original];
+      const colY = columns[j_original];
+      if (!colX || !colY) return;
 
-        const cacheKey = createCacheKey(colX.name, colY.name, colX.scale, colY.scale, dataStateHash, selectedStateHash, filterMode);
+      const canvasKey = `${colX.name}-${colY.name}`;
+      activeCanvases.add(canvasKey);
 
-        const cachedImg = createImageFromCache(cacheKey, i * size, j * size);
-        if (cachedImg) {
-          canvasContainerRef.current!.appendChild(cachedImg);
-        }
-      });
-    } else {
-      // Normal render: clear and recreate canvases with points
-      canvasContainerRef.current.innerHTML = '';
-      canvasElementsRef.current.clear();
+      let canvas = canvasElementsRef.current.get(canvasKey);
+      if (!canvas) {
+        canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        canvas.style.position = 'absolute';
+        canvas.style.pointerEvents = 'none';
+        canvasElementsRef.current.set(canvasKey, canvas);
+      }
 
-      brushableCells.each(function ([i, j]) {
-          const i_original = visibleIndexToOriginalIndex.get(i);
-          const j_original = visibleIndexToOriginalIndex.get(j);
-          if (i_original === undefined || j_original === undefined) return;
+      if (!canvas.isConnected) {
+        container.appendChild(canvas);
+      }
 
-        const colX = columns[i_original];
-        const colY = columns[j_original];
-        if (!colX || !colY) return;
+      canvas.style.left = `${i * size}px`;
+      canvas.style.top = `${j * size}px`;
 
-        const cacheKey = createCacheKey(colX.name, colY.name, colX.scale, colY.scale, dataStateHash, selectedStateHash, filterMode);
+      const renderKey = `${colX.name}-${colY.name}-${colX.scale}-${colY.scale}-${filterMode}-${dataStateHash}-${selectedStateHash}`;
+      const previousKey = canvasRenderKeyRef.current.get(canvasKey);
 
-          // Try to use cached image first
-          const cachedImg = createImageFromCache(cacheKey, i * size, j * size);
-          if (cachedImg) {
-            canvasContainerRef.current!.appendChild(cachedImg);
-            return;
-          }
+      if (!isDraggingRef.current && (previousKey !== renderKey || filterMode === 'filter')) {
+        renderPointsToCanvas(
+          canvas,
+          filteredData,
+          xScales[i],
+          yScales[j],
+          colX.name,
+          colY.name,
+          selectedIds,
+          filterMode
+        );
+        canvasRenderKeyRef.current.set(canvasKey, renderKey);
+      }
+    });
 
-          // No cache - create canvas and render
-          const canvas = document.createElement('canvas');
-          canvas.width = size;
-          canvas.height = size;
-          canvas.style.position = 'absolute';
-          canvas.style.left = `${i * size}px`;
-          canvas.style.top = `${j * size}px`;
-          canvas.style.pointerEvents = 'none';
-          canvasContainerRef.current!.appendChild(canvas);
+    // Remove canvases for columns that are no longer visible
+    const canvasesToRemove: string[] = [];
+    canvasElementsRef.current.forEach((canvas, key) => {
+      if (!activeCanvases.has(key)) {
+        canvas.remove();
+        canvasesToRemove.push(key);
+      }
+    });
 
-          // Store canvas reference for drag repositioning (by column names)
-        const canvasKey = `${colX.name}-${colY.name}`;
-          canvasElementsRef.current.set(canvasKey, canvas);
+    canvasesToRemove.forEach(key => {
+      canvasElementsRef.current.delete(key);
+      canvasRenderKeyRef.current.delete(key);
+    });
 
-          // Render points to canvas
-          renderPointsToCanvas(
-            canvas,
-            filteredData,
-            xScales[i],
-            yScales[j],
-            colX.name,
-            colY.name,
-            selectedIds,
-            filterMode
-          );
-
-          // Cache the rendered canvas as image
-          setTimeout(() => cacheCanvasAsImage(canvas, cacheKey), 0);
-        });
-    }
-      
     const diagonalCells = cell.filter(([i, j]) => i === j);
-    
-    diagonalCells.each(function([i]) {
+
+    diagonalCells.each(function ([i]) {
       const g = d3.select(this);
-    
+
       // Add a data-testid to the diagonal cell for easy selection in tests
       const originalIndex = visibleIndexToOriginalIndex.get(i);
       if (originalIndex !== undefined) {
@@ -477,74 +512,74 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
             .style("fill", "#3f3f46");
         });
     });
-    
+
     if (showHistograms) {
-        brushX
-          .on("end", function(event) {
-            if (!event.sourceEvent) return;
-            const parentNode = this.parentNode as Element;
-            if (!parentNode) return;
-            const i_visible = parseInt(d3.select(parentNode).attr("data-index")!, 10);
-            const i_original = visibleIndexToOriginalIndex.get(i_visible);
-            
-            if (i_original === undefined || !columns[i_original]) return;
+      brushX
+        .on("end", function (event) {
+          if (!event.sourceEvent) return;
+          const parentNode = this.parentNode as Element;
+          if (!parentNode) return;
+          const i_visible = parseInt(d3.select(parentNode).attr("data-index")!, 10);
+          const i_original = visibleIndexToOriginalIndex.get(i_visible);
 
-            if (!event.selection) { onBrush(null); return; }
+          if (i_original === undefined || !columns[i_original]) return;
 
-            const [x0, x1] = event.selection;
-            // Faster selection for histogram brush
-            const newSelectedIds = new Set<number>();
-            const minVal = xScales[i_visible].invert(x0);
-            const maxVal = xScales[i_visible].invert(x1);
-            for (const d of data) {
-                const val = +d[columns[i_original].name];
-                if (val >= minVal && val <= maxVal) newSelectedIds.add(d.__id);
-            }
-            onBrush({ indexX: i_original, indexY: columns.length, x0, y0: padding/2, x1, y1: size - padding/2, selectedIds: newSelectedIds });
+          if (!event.selection) { onBrush(null); return; }
+
+          const [x0, x1] = event.selection;
+          // Faster selection for histogram brush
+          const newSelectedIds = new Set<number>();
+          const minVal = xScales[i_visible].invert(x0);
+          const maxVal = xScales[i_visible].invert(x1);
+          for (const d of data) {
+            const val = +d[columns[i_original].name];
+            if (val >= minVal && val <= maxVal) newSelectedIds.add(d.__id);
+          }
+          onBrush({ indexX: i_original, indexY: columns.length, x0, y0: padding / 2, x1, y1: size - padding / 2, selectedIds: newSelectedIds });
         });
 
       histCellsBottom = svg.append("g").selectAll("g").data(d3.range(n)).join("g")
         .attr("transform", i => `translate(${i * size}, ${n * size})`)
         .attr("data-index", i => i)
         .call(brushX);
-        
-      histCellsBottom.each(function(i_visible) {
+
+      histCellsBottom.each(function (i_visible) {
         const i_original = visibleIndexToOriginalIndex.get(i_visible)!;
         const allValues = filteredData.map(d => +d[columns[i_original].name]).filter(isFinite);
         const selectedValues = selectedData.map(d => +d[columns[i_original].name]).filter(isFinite);
 
         const domain = xScales[i_visible].domain();
         const binGenerator = d3.bin().domain([Math.min(domain[0], domain[1]), Math.max(domain[0], domain[1])]).thresholds(20);
-        
+
         const allBins = binGenerator(allValues);
         const selectedBins = binGenerator(selectedValues);
-        
+
         const combinedBins = allBins.map((bin, index) => ({
           x0: bin.x0, x1: bin.x1,
           totalLength: bin.length,
           selectedLength: selectedBins[index]?.length || 0
         }));
 
-        const yHist = d3.scaleLinear().domain([0, d3.max(combinedBins, d => d.totalLength) || 1]).range([size - padding/2, padding/2]);
-        
+        const yHist = d3.scaleLinear().domain([0, d3.max(combinedBins, d => d.totalLength) || 1]).range([size - padding / 2, padding / 2]);
+
         const g = d3.select(this);
         g.selectAll("rect.total").data(combinedBins).join("rect").attr("class", "total")
-            .attr("x", d => xScales[i_visible](d.x0!)! + 1)
-            .attr("width", d => Math.max(0, xScales[i_visible](d.x1!)! - xScales[i_visible](d.x0!)! - 1))
-            .attr("y", d => yHist(d.totalLength)!)
-            .attr("height", d => size - padding/2 - yHist(d.totalLength)!)
-            .attr("fill", selectedIds.size > 0 ? "#ccc" : "#60a5fa");
+          .attr("x", d => xScales[i_visible](d.x0!)! + 1)
+          .attr("width", d => Math.max(0, xScales[i_visible](d.x1!)! - xScales[i_visible](d.x0!)! - 1))
+          .attr("y", d => yHist(d.totalLength)!)
+          .attr("height", d => size - padding / 2 - yHist(d.totalLength)!)
+          .attr("fill", selectedIds.size > 0 ? "#ccc" : "#60a5fa");
 
         g.selectAll("rect.selected").data(combinedBins).join("rect").attr("class", "selected")
-            .attr("x", d => xScales[i_visible](d.x0!)! + 1)
-            .attr("width", d => Math.max(0, xScales[i_visible](d.x1!)! - xScales[i_visible](d.x0!)! - 1))
-            .attr("y", d => yHist(d.selectedLength)!)
-            .attr("height", d => size - padding/2 - yHist(d.selectedLength)!)
-            .attr("fill", "#1e40af");
+          .attr("x", d => xScales[i_visible](d.x0!)! + 1)
+          .attr("width", d => Math.max(0, xScales[i_visible](d.x1!)! - xScales[i_visible](d.x0!)! - 1))
+          .attr("y", d => yHist(d.selectedLength)!)
+          .attr("height", d => size - padding / 2 - yHist(d.selectedLength)!)
+          .attr("fill", "#1e40af");
       });
-      
+
       brushY
-        .on("end", function(event) {
+        .on("end", function (event) {
           if (!event.sourceEvent) return;
           const parentNode = this.parentNode as Element;
           if (!parentNode) return;
@@ -552,7 +587,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           const j_original = visibleIndexToOriginalIndex.get(j_visible);
 
           if (j_original === undefined || !columns[j_original]) return;
-          
+
           if (!event.selection) { onBrush(null); return; }
 
           const [y0, y1] = event.selection;
@@ -561,25 +596,25 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           const minVal = yScales[j_visible].invert(y1);
           const maxVal = yScales[j_visible].invert(y0);
           for (const d of data) {
-              const val = +d[columns[j_original].name];
-              if (val >= minVal && val <= maxVal) newSelectedIds.add(d.__id);
+            const val = +d[columns[j_original].name];
+            if (val >= minVal && val <= maxVal) newSelectedIds.add(d.__id);
           }
-          onBrush({ indexX: columns.length, indexY: j_original, x0: padding/2, y0, x1: size - padding/2, y1, selectedIds: newSelectedIds });
-      });
+          onBrush({ indexX: columns.length, indexY: j_original, x0: padding / 2, y0, x1: size - padding / 2, y1, selectedIds: newSelectedIds });
+        });
 
       histCellsRight = svg.append("g").selectAll("g").data(d3.range(n)).join("g")
         .attr("transform", i => `translate(${n * size}, ${i * size})`)
         .attr("data-index", i => i)
         .call(brushY);
 
-      histCellsRight.each(function(j_visible) {
+      histCellsRight.each(function (j_visible) {
         const j_original = visibleIndexToOriginalIndex.get(j_visible)!;
         const allValues = filteredData.map(d => +d[columns[j_original].name]).filter(isFinite);
         const selectedValues = selectedData.map(d => +d[columns[j_original].name]).filter(isFinite);
 
         const domain = yScales[j_visible].domain();
         const binGenerator = d3.bin().domain([Math.min(domain[0], domain[1]), Math.max(domain[0], domain[1])]).thresholds(20);
-        
+
         const allBins = binGenerator(allValues);
         const selectedBins = binGenerator(selectedValues);
 
@@ -588,31 +623,31 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           totalLength: bin.length,
           selectedLength: selectedBins[index]?.length || 0
         }));
-        
-        const xHist = d3.scaleLinear().domain([0, d3.max(combinedBins, d => d.totalLength) || 1]).range([padding/2, size - padding/2]);
+
+        const xHist = d3.scaleLinear().domain([0, d3.max(combinedBins, d => d.totalLength) || 1]).range([padding / 2, size - padding / 2]);
         const g = d3.select(this);
 
         g.selectAll("rect.total").data(combinedBins).join("rect").attr("class", "total")
-            .attr("y", d => yScales[j_visible](d.x1!)! + 1)
-            .attr("height", d => Math.max(0, yScales[j_visible](d.x0!)! - yScales[j_visible](d.x1!)! - 1))
-            .attr("x", padding/2)
-            .attr("width", d => xHist(d.totalLength)! - padding/2)
-            .attr("fill", selectedIds.size > 0 ? "#ccc" : "#60a5fa");
-        
+          .attr("y", d => yScales[j_visible](d.x1!)! + 1)
+          .attr("height", d => Math.max(0, yScales[j_visible](d.x0!)! - yScales[j_visible](d.x1!)! - 1))
+          .attr("x", padding / 2)
+          .attr("width", d => xHist(d.totalLength)! - padding / 2)
+          .attr("fill", selectedIds.size > 0 ? "#ccc" : "#60a5fa");
+
         g.selectAll("rect.selected").data(combinedBins).join("rect").attr("class", "selected")
-            .attr("y", d => yScales[j_visible](d.x1!)! + 1)
-            .attr("height", d => Math.max(0, yScales[j_visible](d.x0!)! - yScales[j_visible](d.x1!)! - 1))
-            .attr("x", padding/2)
-            .attr("width", d => xHist(d.selectedLength)! - padding/2)
-            .attr("fill", "#1e40af");
+          .attr("y", d => yScales[j_visible](d.x1!)! + 1)
+          .attr("height", d => Math.max(0, yScales[j_visible](d.x0!)! - yScales[j_visible](d.x1!)! - 1))
+          .attr("x", padding / 2)
+          .attr("width", d => xHist(d.selectedLength)! - padding / 2)
+          .attr("fill", "#1e40af");
       });
     }
-    
+
     // Declaratively sync the brush visual state with the React state.
-    brushableCells.each(function([i_visible, j_visible]) {
+    brushableCells.each(function ([i_visible, j_visible]) {
       const i_original = visibleIndexToOriginalIndex.get(i_visible);
       const j_original = visibleIndexToOriginalIndex.get(j_visible);
-      
+
       if (brushSelection && brushSelection.indexX === i_original && brushSelection.indexY === j_original) {
         d3.select(this).call(brush.move, [[brushSelection.x0, brushSelection.y0], [brushSelection.x1, brushSelection.y1]]);
       } else {
@@ -621,7 +656,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     });
 
     if (showHistograms && histCellsBottom) {
-      histCellsBottom.each(function(i_visible) {
+      histCellsBottom.each(function (i_visible) {
         const i_original = visibleIndexToOriginalIndex.get(i_visible);
         if (brushSelection && brushSelection.indexX === i_original && brushSelection.indexY === columns.length) {
           d3.select(this).call(brushX.move, [brushSelection.x0, brushSelection.x1]);
@@ -630,9 +665,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         }
       });
     }
-    
+
     if (showHistograms && histCellsRight) {
-       histCellsRight.each(function(j_visible) {
+      histCellsRight.each(function (j_visible) {
         const j_original = visibleIndexToOriginalIndex.get(j_visible);
         if (brushSelection && brushSelection.indexX === columns.length && brushSelection.indexY === j_original) {
           d3.select(this).call(brushY.move, [brushSelection.y0, brushSelection.y1]);
@@ -642,37 +677,47 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       });
     }
 
-  }, [data, columns, onBrush, filteredData, selectedData, selectedIds, size, padding, n, showHistograms, filterMode, labelColumn, onPointHover, onPointLeave, brushSelection, visibleColumns, visibleIndexToOriginalIndex, originalIndexToVisibleIndex, createSpatialGrid, getPointsInBrush, renderPointsToCanvas, cacheCanvasAsImage, createImageFromCache, createCacheKey, dataStateHash, selectedStateHash, scaleDependency]);
+  }, [data, columns, onBrush, filteredData, selectedData, selectedIds, size, padding, n, showHistograms, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, createSpatialGrid, getPointsInBrush, renderPointsToCanvas, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash]);
 
   return (
     <div className="w-full h-full relative">
-       <div style={{
+      <div
+        style={{
           position: 'absolute',
-          display: 'grid',
-          gridTemplateColumns: `repeat(${showHistograms ? n + 1 : n}, ${size}px)`,
-          gridTemplateRows: `repeat(${showHistograms ? n + 1 : n}, ${size}px)`,
-          gap: '0px',
+          top: 0,
+          left: 0,
+          width: plotSize,
+          height: plotSize,
           pointerEvents: 'none'
-        }}>
-          {n > 0 && d3.cross(d3.range(n), d3.range(n)).map(([i, j]) => {
-              if (i === j) {
-                  const originalIndex = visibleIndexToOriginalIndex.get(i)!;
-                  const column = columns[originalIndex];
-                  return (
-                    <div key={column.name} style={{ gridColumn: i + 1, gridRow: j + 1, pointerEvents: 'auto' }}>
-                        <DraggableHeader
-                          name={column.name}
-                          index={originalIndex}
-                          onColumnReorder={onColumnReorder}
-                          onDragStart={handleDragStart}
-                          onDragEnd={handleDragEnd}
-                        />
-                    </div>
-                  );
-              }
-              return <div key={`${i}-${j}`} style={{ gridColumn: i + 1, gridRow: j + 1 }}></div>
-          })}
-        </div>
+        }}
+      >
+        {headerIndices.map(i => {
+          const originalIndex = visibleIndexToOriginalIndex.get(i);
+          if (originalIndex === undefined) return null;
+          const column = columns[originalIndex];
+          return (
+            <div
+              key={column.name}
+              style={{
+                position: 'absolute',
+                left: i * size,
+                top: i * size,
+                width: size,
+                height: size,
+                pointerEvents: 'auto'
+              }}
+            >
+              <DraggableHeader
+                name={column.name}
+                index={originalIndex}
+                onColumnReorder={onColumnReorder}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+              />
+            </div>
+          );
+        })}
+      </div>
       {/* Canvas container for high-performance point rendering */}
       <div
         ref={canvasContainerRef}

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -297,11 +297,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       }
 
       if (column.scale === 'log') {
-        const start = Math.max(1e-9, Math.min(stat.minPositive, stat.max));
-        let end = Math.max(1e-9, stat.max);
-        if (start >= end) {
-          end = start * 10;
-        }
+        const start = isFinite(stat.minPositive) ? stat.minPositive : 1e-9;
+        const end = stat.max > start ? stat.max : start * 10;
         return d3.scaleLog().domain([start, end]).range(range);
       }
 
@@ -456,7 +453,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       const renderKey = `${colX.name}-${colY.name}-${colX.scale}-${colY.scale}-${filterMode}-${dataStateHash}-${selectedStateHash}`;
       const previousKey = canvasRenderKeyRef.current.get(canvasKey);
 
-      if (!isDraggingRef.current && (previousKey !== renderKey || filterMode === 'filter')) {
+      if (!isDraggingRef.current && previousKey !== renderKey) {
         renderPointsToCanvas(
           canvas,
           filteredData,

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -338,7 +338,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     svg.selectAll("*").remove(); // Clear previous render
 
     const createScale = (c: Column, range: [number, number]) => {
-      // Force coersion to number and filter out non-finite values
+      // Force coercion to number and filter out non-finite values
       const values = data.map(d => +d[c.name]).filter(isFinite);
       const extent = d3.extent(values);
 

--- a/src/utils/columnUtils.ts
+++ b/src/utils/columnUtils.ts
@@ -1,5 +1,4 @@
 import type { Column } from '../types';
-import { filterData } from '../utils/dataUtils';
 
 export function reorderColumns(columns: Column[], dragIndex: number, hoverIndex: number): Column[] {
     const newColumns = [...columns];
@@ -8,10 +7,25 @@ export function reorderColumns(columns: Column[], dragIndex: number, hoverIndex:
 }
 
 export function filterColumns(columns: Column[], filter: string): Column[] {
-    return columns.map(col => ({
-        ...col,
-        visible: filter === '' || col.name.toLowerCase().includes(filter.toLowerCase())
-    }));
+    const normalizedFilter = filter.trim().toLowerCase();
+    const shouldShowAll = normalizedFilter === '';
+
+    let didChange = false;
+    const nextColumns: Column[] = new Array(columns.length);
+
+    for (let index = 0; index < columns.length; index++) {
+        const col = columns[index];
+        const shouldBeVisible = shouldShowAll || col.name.toLowerCase().includes(normalizedFilter);
+
+        if (col.visible === shouldBeVisible) {
+            nextColumns[index] = col;
+        } else {
+            didChange = true;
+            nextColumns[index] = { ...col, visible: shouldBeVisible };
+        }
+    }
+
+    return didChange ? nextColumns : columns;
 }
 
 export function mapVisibleColumns(


### PR DESCRIPTION
## Summary
- reuse cached canvases and memoized column stats to avoid redundant scatter plot matrix rendering
- streamline draggable header rendering and skip unnecessary canvas work while reordering columns
- make column filtering stable to prevent needless state updates when searching

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfe7616f10832793fa9e0064e05142