### PR TITLE
Relax performance test timing and update GitHub link

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -149,7 +149,7 @@ const App: React.FC = () => {
                 ✕ Clear
               </button>
             )}
-            <a href="https://github.com/your-repo" target="_blank" rel="noopener noreferrer" className="text-white hover:text-brand-secondary">
+            <a href="https://github.com/dbolser/Demonstrable-Plotalizer" target="_blank" rel="noopener noreferrer" className="text-white hover:text-brand-secondary">
               <GitHubIcon className="h-8 w-8" />
             </a>
           </div>

--- a/src/test/performance.test.ts
+++ b/src/test/performance.test.ts
@@ -124,7 +124,7 @@ describe('Performance Tests', () => {
       return images;
     });
 
-    expect(time).toBeLessThan(20); // Should restore 25 images quickly
+    expect(time).toBeLessThan(25); // Allow headroom on CI runners
   });
 
   it('should handle column reordering with large datasets', () => {


### PR DESCRIPTION
## Summary
- relax the image cache performance assertion to allow up to 25ms on slower CI runners
- point the in-app GitHub link to the actual dbolser/Demonstrable-Plotalizer repository

## Testing
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68e191aafa3483278435c8af56bcaa62