### PR TITLE
Improve large dataset responsiveness and show loading feedback

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useTransition } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import Papa from 'papaparse';
@@ -7,6 +7,7 @@ import { ControlPanel } from './components/ControlPanel';
 import { ScatterPlotMatrix } from './components/ScatterPlotMatrix';
 import { Tooltip } from './components/Tooltip';
 import { DataTable } from './components/DataTable';
+import { LoadingOverlay } from './components/LoadingOverlay';
 import type { DataPoint, Column, ScaleType, BrushSelection, FilterMode } from './types';
 import { GitHubIcon } from './components/icons';
 import { reorderColumns, filterColumns } from './src/utils/columnUtils';
@@ -27,12 +28,26 @@ const App: React.FC = () => {
     x: 0,
     y: 0,
   });
+  const [loadingPhase, setLoadingPhase] = useState<'idle' | 'loadingData'>('idle');
+  const [loadingElapsed, setLoadingElapsed] = useState(0);
+  const [renderProgress, setRenderProgress] = useState<{ active: boolean; total: number; completed: number }>({
+    active: false,
+    total: 0,
+    completed: 0,
+  });
+  const [renderElapsed, setRenderElapsed] = useState(0);
+  const [, startFilterTransition] = useTransition();
 
   const loadSampleData = useCallback(() => {
+    setLoadingPhase('loadingData');
     fetch('/data/sample.csv')
       .then(response => response.text())
       .then(csvText => {
         handleDataLoaded(csvText);
+      })
+      .catch(error => {
+        console.error('Failed to load sample data', error);
+        setLoadingPhase('idle');
       });
   }, []);
 
@@ -52,38 +67,54 @@ const App: React.FC = () => {
   }, []);
 
   const handleDataLoaded = (csvText: string) => {
-    const result = Papa.parse<DataPoint>(csvText, { header: true, dynamicTyping: true, skipEmptyLines: true });
-    if (result.errors.length > 0) {
-      console.error("CSV Parsing errors:", result.errors);
-      alert("Error parsing CSV file. Check console for details.");
-      return;
-    }
+    setLoadingPhase('loadingData');
+    setRenderProgress({ active: false, total: 0, completed: 0 });
 
-    const rawData = result.data;
-    if (rawData.length === 0) {
-      setData([]);
-      setColumns([]);
-      setLabelColumn(null);
-      return;
-    }
-    
-    // Add a unique ID to each data point
-    const dataWithIds = rawData.map((d, i) => ({ ...d, __id: i }));
-    setData(dataWithIds);
+    Papa.parse<DataPoint>(csvText, {
+      header: true,
+      dynamicTyping: true,
+      skipEmptyLines: true,
+      worker: true,
+      complete: (result) => {
+        if (result.errors.length > 0) {
+          console.error('CSV Parsing errors:', result.errors);
+          alert('Error parsing CSV file. Check console for details.');
+          setLoadingPhase('idle');
+          return;
+        }
 
-    // Auto-detect the first string column as the label
-    const firstStringCol = result.meta.fields?.find(field => typeof rawData[0][field] === 'string');
-    setLabelColumn(firstStringCol || null);
+        const rawData = result.data;
+        if (rawData.length === 0) {
+          setData([]);
+          setColumns([]);
+          setLabelColumn(null);
+          setLoadingPhase('idle');
+          return;
+        }
 
-    const numericColumns = Object.keys(dataWithIds[0])
-      .filter(key => typeof dataWithIds[0][key] === 'number' && key !== '__id')
-      .map(key => ({
-        name: key,
-        scale: 'linear' as ScaleType,
-        visible: true,
-      }));
-    setColumns(numericColumns);
-    setBrushSelection(null);
+        const dataWithIds = rawData.map((d, i) => ({ ...d, __id: i }));
+        setData(dataWithIds);
+
+        const firstStringCol = result.meta.fields?.find(field => typeof rawData[0][field] === 'string');
+        setLabelColumn(firstStringCol || null);
+
+        const numericColumns = Object.keys(dataWithIds[0])
+          .filter(key => typeof dataWithIds[0][key] === 'number' && key !== '__id')
+          .map(key => ({
+            name: key,
+            scale: 'linear' as ScaleType,
+            visible: true,
+          }));
+        setColumns(numericColumns);
+        setBrushSelection(null);
+        setLoadingPhase('idle');
+      },
+      error: (error) => {
+        console.error('CSV Parsing error:', error);
+        alert('Error parsing CSV file. Check console for details.');
+        setLoadingPhase('idle');
+      },
+    });
   };
 
   const handleColumnReorder = (dragIndex: number, hoverIndex: number) => {
@@ -113,7 +144,9 @@ const App: React.FC = () => {
 
   const handleColumnFilterChange = (filter: string) => {
     setColumnFilter(filter);
-    setColumns(prevColumns => filterColumns(prevColumns, filter));
+    startFilterTransition(() => {
+      setColumns(prevColumns => filterColumns(prevColumns, filter));
+    });
   };
 
   const handleGlobalLogScaleToggle = (useLog: boolean) => {
@@ -124,9 +157,83 @@ const App: React.FC = () => {
   };
 
   // Compute data to show in the table (only selected points if there's a selection)
-  const tableData = brushSelection?.selectedIds 
+  const tableData = brushSelection?.selectedIds
     ? data.filter(row => brushSelection.selectedIds.has(row.__id))
     : [];
+
+  useEffect(() => {
+    if (loadingPhase !== 'loadingData') {
+      setLoadingElapsed(0);
+      return;
+    }
+
+    const start = performance.now();
+    setLoadingElapsed(0);
+    const interval = window.setInterval(() => {
+      setLoadingElapsed(performance.now() - start);
+    }, 100);
+    return () => window.clearInterval(interval);
+  }, [loadingPhase]);
+
+  useEffect(() => {
+    if (!renderProgress.active) {
+      setRenderElapsed(0);
+      return;
+    }
+
+    const start = performance.now();
+    setRenderElapsed(0);
+    const interval = window.setInterval(() => {
+      setRenderElapsed(performance.now() - start);
+    }, 100);
+    return () => window.clearInterval(interval);
+  }, [renderProgress.active]);
+
+  const handleRenderLifecycle = useCallback((event: { phase: 'rendering' | 'idle'; total: number; completed: number }) => {
+    setRenderProgress(prev => {
+      if (event.phase === 'rendering' && event.total > 0) {
+        return {
+          active: true,
+          total: event.total,
+          completed: Math.min(event.completed, event.total),
+        };
+      }
+
+      if (event.phase === 'idle') {
+        return {
+          active: false,
+          total: event.total,
+          completed: Math.min(event.completed, event.total),
+        };
+      }
+
+      return prev;
+    });
+  }, []);
+
+  const overlay = (() => {
+    if (loadingPhase === 'loadingData') {
+      return (
+        <LoadingOverlay
+          message="Loading data"
+          detail={`Elapsed time: ${(loadingElapsed / 1000).toFixed(1)}s`}
+        />
+      );
+    }
+
+    if (renderProgress.active && renderProgress.total > 0) {
+      const progress = renderProgress.completed / renderProgress.total;
+      return (
+        <LoadingOverlay
+          message="Rendering scatter plots"
+          detail={`Rendered ${renderProgress.completed} of ${renderProgress.total} • ${(renderElapsed / 1000).toFixed(1)}s elapsed`}
+          progress={progress}
+        />
+      );
+    }
+
+    return null;
+  })();
 
   // Resizable table panel
   const [tableHeight, setTableHeight] = useState(300); // pixels
@@ -162,6 +269,7 @@ const App: React.FC = () => {
   if (!columns.length) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 text-gray-700">
+        {overlay}
         <div className="max-w-xl text-center p-8 bg-white rounded-lg shadow-md">
           <h1 className="text-3xl font-bold text-brand-primary mb-4">Interactive Scatter Plot Matrix</h1>
           <p className="mb-6">Upload a CSV file to begin visualizing your data, or load the sample dataset to explore the tool's features.</p>
@@ -182,6 +290,7 @@ const App: React.FC = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="flex flex-col h-screen font-sans">
+        {overlay}
         <Tooltip content={tooltip.content} x={tooltip.x} y={tooltip.y} visible={tooltip.visible} />
         <header className="bg-brand-dark text-white p-4 shadow-md flex justify-between items-center">
           <h1 className="text-2xl font-bold">Interactive Scatter Plot Matrix</h1>
@@ -239,6 +348,7 @@ const App: React.FC = () => {
                 labelColumn={labelColumn}
                 onPointHover={handlePointHover}
                 onPointLeave={handlePointLeave}
+                onRenderLifecycle={handleRenderLifecycle}
               />
             </div>
             {tableData.length > 0 && (

--- a/components/LoadingOverlay.tsx
+++ b/components/LoadingOverlay.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface LoadingOverlayProps {
+  message: string;
+  detail?: string;
+  progress?: number;
+}
+
+export const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ message, detail, progress }) => {
+  const clampedProgress = typeof progress === 'number'
+    ? Math.max(0, Math.min(1, progress))
+    : undefined;
+
+  const percent = clampedProgress !== undefined
+    ? Math.round(clampedProgress * 100)
+    : undefined;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <div className="w-80 max-w-full rounded-xl bg-white p-6 shadow-2xl">
+        <div className="text-lg font-semibold text-brand-dark">{message}</div>
+        {detail && (
+          <p className="mt-2 text-sm text-gray-600">{detail}</p>
+        )}
+        {clampedProgress !== undefined && (
+          <div className="mt-4">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+              <div
+                className="h-full rounded-full bg-brand-secondary transition-all duration-200 ease-out"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+            <div className="mt-2 text-xs font-medium text-gray-500">
+              {percent}% complete
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add global loading and rendering overlays with elapsed time tracking for data ingestion and plot generation
- parse CSV data in a background worker, defer column filtering updates, and surface render progress from the scatter plot matrix
- stream canvas redraws across animation frames to avoid UI stalls while reporting progress back to the overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e39a29d9a08327898a1ef5e86649c4