### PR TITLE
Improve spatial grid typing

### DIFF
--- a/src/utils/selectionUtils.ts
+++ b/src/utils/selectionUtils.ts
@@ -1,3 +1,5 @@
+import type { DataPoint } from '../../types';
+
 export function computeSelectedStateHash(selectedIds: Set<number>): string {
     // Return a concise string that changes whenever the membership of the set changes,
     // but is independent of insertion order. We combine the size with a simple additive hash
@@ -24,8 +26,8 @@ export function createSpatialGrid(
     size: number,
     gridSize = 20
 ): DataPoint[][][] {
-    const grid: any[][][] = Array.from({ length: gridSize }, () =>
-        Array.from({ length: gridSize }, () => [])
+    const grid: DataPoint[][][] = Array.from({ length: gridSize }, () =>
+        Array.from({ length: gridSize }, () => [] as DataPoint[])
     );
     data.forEach((d) => {
         const x = +d[xCol];


### PR DESCRIPTION
## Summary
- import the shared DataPoint type for selection utilities
- strongly type the spatial grid cache to hold DataPoint entries

## Testing
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68e6eaac629c8327a7f9ef4e75c35194