### PR TITLE
fix: resolve TypeScript errors and add typecheck gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Typecheck
+      run: npm run typecheck
+
     - name: Run tests
       run: npm run test:run
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "deploy": "npm run build && echo 'Build complete! Deployment to GitHub Pages is triggered automatically by pushing to the main branch.'",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",

--- a/src/test/columnReordering.test.ts
+++ b/src/test/columnReordering.test.ts
@@ -104,7 +104,7 @@ describe('Column Filtering Logic', () => {
 
   it('should show all columns when filter is empty', () => {
     const columns = createMockColumns(['col1', 'col2', 'col3']);
-    const filter = '';
+    const filter: string = '';
 
     const filteredColumns = columns.map(col => ({
       ...col,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 
 // Mock canvas and image operations for testing
 HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
@@ -8,7 +9,7 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
   fill: vi.fn(),
   beginPath: vi.fn(),
   drawImage: vi.fn(),
-}));
+})) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
 HTMLCanvasElement.prototype.toDataURL = vi.fn(() => 'data:image/png;base64,mock');
 

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -1,4 +1,4 @@
-import type { DataPoint, FilterMode } from '../types';
+import type { DataPoint, FilterMode } from '../../types';
 
 export function filterData(
     data: DataPoint[],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vite/client"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,


### PR DESCRIPTION
## What was broken

`npx tsc --noEmit` failed on main, but nobody noticed because the build script is a plain `vite build` (esbuild strips types without checking them) and CI only ran tests + build. Errors on main:

- `src/utils/dataUtils.ts` imported from `../types`, which does not exist — `types.ts` lives at the repo root, so from `src/utils` the correct path is `../../types` (TS2307)
- `src/test/setup.ts` used `vi` without importing it from `vitest` (TS2304 x13)
- `App.tsx` used `import.meta.env.BASE_URL` but `vite/client` types were not in `tsconfig.json`, so `ImportMeta.env` did not exist (TS2339)
- `src/test/columnReordering.test.ts` declared `const filter = ''` (literal type `''`), so after the `filter === ''` guard TS narrowed `filter` to `never` in the right-hand operand (TS2339)

## What was fixed

- `src/utils/dataUtils.ts`: import path `../types` → `../../types`
- `src/test/setup.ts`: `import { vi } from 'vitest'`; cast the `getContext` mock to the DOM signature (importing `vi` gave the mock a real type, exposing the mismatch)
- `tsconfig.json`: add `"vite/client"` to `types`
- `src/test/columnReordering.test.ts`: annotate `filter: string` to widen the literal
- `package.json`: new `"typecheck": "tsc --noEmit"` script
- `.github/workflows/ci.yml`: run `npm run typecheck` before tests so this class of regression fails CI

No behavior changes — all edits are types/config only.

## Verification

- `npx tsc --noEmit`: clean, zero errors
- `npm run test:run`: 9 test files, 61/61 tests passed
- `npm run build`: succeeds (711 modules transformed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by adding a TypeScript type-check step to automated checks.
  * Updated test setup to better support browser-canvas mocking in test runs.
* **Chores**
  * Added a project script for running type checks locally.
  * Adjusted TypeScript configuration to include browser client types for smoother tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->