### PR TITLE
fix+feat: robust table divider drag; data table available via toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ import { fetchCsvFromUrl, getDataUrlFromQuery } from './src/utils/urlLoader';
 import { UrlInput } from './components/UrlInput';
 import { computePCA, projectPCA, PCA_COLUMN_NAMES } from './src/utils/pca';
 import type { PCAVarianceEntry } from './components/ControlPanel';
+import { clampTableHeight, computeDragHeight, isTableVisible, capTableRows } from './src/utils/tableLayout';
 
 const MAX_INITIAL_RENDER_POINTS = 15_000;
 
@@ -358,52 +359,95 @@ const App: React.FC = () => {
     })));
   }, [data, displayColumns]);
 
-  // Compute data to show in the table (only selected points if there's a selection).
+  // Issue #56: the data table is available via a persistent toggle. When a
+  // brush selection exists the table shows the selected rows (and still
+  // auto-appears even with the toggle off, so the feature stays
+  // discoverable); with the toggle on and no selection it shows the full
+  // dataset capped at the first TABLE_ROW_CAP rows.
+  const [showDataTable, setShowDataTable] = useState<boolean>(false);
+
+  const hasActiveSelection = !!brushSelection?.selectedIds && brushSelection.selectedIds.size > 0;
+
   // Memoized so per-frame render-progress updates don't re-filter large datasets.
-  const tableData = useMemo(
-    () => brushSelection?.selectedIds
-      ? data.filter(row => brushSelection.selectedIds.has(row.__id))
-      : [],
-    [brushSelection, data]
-  );
+  const { tableRows, tableCapNote } = useMemo(() => {
+    if (hasActiveSelection && brushSelection?.selectedIds) {
+      return {
+        tableRows: data.filter(row => brushSelection.selectedIds.has(row.__id)),
+        tableCapNote: null as string | null,
+      };
+    }
+    if (showDataTable) {
+      const { rows, capNote } = capTableRows(data);
+      return { tableRows: rows, tableCapNote: capNote };
+    }
+    return { tableRows: [], tableCapNote: null as string | null };
+  }, [brushSelection, data, hasActiveSelection, showDataTable]);
 
-  // B3: Resizable table panel — fixed drag logic
+  const tableVisible = isTableVisible(showDataTable, hasActiveSelection) && tableRows.length > 0;
+
+  // B3 / issue #49: Resizable table panel.
+  //
+  // Drag mechanics: pointer events + setPointerCapture on the divider, so the
+  // drag keeps tracking when the cursor leaves the 12px handle or the window
+  // (the old mouse-event version lost the mouseup outside the window and got
+  // stuck in drag mode). During the drag the height is written straight to
+  // the panel's DOM style — no React state per move — so App (and the whole
+  // scatter-plot matrix component tree) does not re-render on every
+  // pointermove; the matrix container just shrinks and scrolls, its canvases
+  // never repaint. State is committed once on pointerup. The height is
+  // computed from the drag-start anchor + absolute pointer position (no
+  // incremental deltas), and the anchor is the panel's *rendered* height, so
+  // the panel can never jump at drag start even if state and layout disagree.
   const [tableHeight, setTableHeight] = useState(300);
-  const [isDragging, setIsDragging] = useState(false);
-  const dragStartRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const tablePanelRef = useRef<HTMLDivElement>(null);
+  const dividerDragRef = useRef<{
+    pointerId: number;
+    startY: number;
+    startHeight: number;
+    containerHeight: number;
+  } | null>(null);
 
-  useEffect(() => {
-    if (!isDragging) return;
-
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!dragStartRef.current) return;
-      const { startY, startHeight } = dragStartRef.current;
-      const newHeight = startHeight + (startY - e.clientY);
-      const mainElement = document.querySelector('main');
-      const maxHeight = mainElement ? mainElement.getBoundingClientRect().height * 0.8 : 600;
-      setTableHeight(Math.max(100, Math.min(maxHeight, newHeight)));
+  const handleDividerPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault(); // No text selection / native drag
+    const panelHeight = tablePanelRef.current?.getBoundingClientRect().height ?? tableHeight;
+    const mainElement = e.currentTarget.parentElement;
+    dividerDragRef.current = {
+      pointerId: e.pointerId,
+      startY: e.clientY,
+      startHeight: panelHeight,
+      containerHeight: mainElement?.getBoundingClientRect().height ?? window.innerHeight,
     };
-
-    const handleMouseUp = () => {
-      setIsDragging(false);
-      document.body.style.userSelect = '';
-      dragStartRef.current = null;
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-
-    return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    };
-  }, [isDragging]);
-
-  const handleDragHandleMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault(); // Prevent browser default drag behaviour
-    dragStartRef.current = { startY: e.clientY, startHeight: tableHeight };
-    setIsDragging(true);
+    e.currentTarget.setPointerCapture(e.pointerId);
     document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'row-resize';
+  };
+
+  const handleDividerPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dividerDragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    const next = clampTableHeight(
+      computeDragHeight(drag.startHeight, drag.startY, e.clientY),
+      drag.containerHeight
+    );
+    if (tablePanelRef.current) {
+      tablePanelRef.current.style.height = `${next}px`;
+    }
+  };
+
+  const handleDividerPointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dividerDragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    dividerDragRef.current = null;
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    // Commit the final height to state (single React render for the drag).
+    const finalHeight = tablePanelRef.current?.getBoundingClientRect().height;
+    if (finalHeight) {
+      setTableHeight(Math.round(finalHeight));
+    }
   };
 
   // Global loading indicator — visible in both empty and main views
@@ -488,6 +532,8 @@ const App: React.FC = () => {
               setFilterMode={setFilterMode}
               showHistograms={showHistograms}
               setShowHistograms={setShowHistograms}
+              showDataTable={showDataTable}
+              setShowDataTable={setShowDataTable}
               useUniformLogBins={useUniformLogBins}
               setUseUniformLogBins={setUseUniformLogBins}
               globalLogScale={globalLogScale}
@@ -526,7 +572,7 @@ const App: React.FC = () => {
             <div
               className="p-4 overflow-auto"
               style={{
-                flex: tableData.length > 0 ? '1 1 auto' : '1 1 0',
+                flex: tableVisible ? '1 1 auto' : '1 1 0',
                 minHeight: 0
               }}
             >
@@ -547,23 +593,30 @@ const App: React.FC = () => {
                 onRenderProgress={handleRenderProgress}
               />
             </div>
-            {tableData.length > 0 && (
+            {tableVisible && (
               <>
                 <div
                   className="h-3 bg-gray-300 hover:bg-brand-primary cursor-row-resize flex items-center justify-center transition-colors flex-shrink-0"
-                  onMouseDown={handleDragHandleMouseDown}
+                  style={{ touchAction: 'none' }}
+                  onPointerDown={handleDividerPointerDown}
+                  onPointerMove={handleDividerPointerMove}
+                  onPointerUp={handleDividerPointerEnd}
+                  onPointerCancel={handleDividerPointerEnd}
                   title="Drag to resize table"
                 >
                   <div className="w-12 h-1 bg-gray-500 rounded"></div>
                 </div>
                 <div
-                  style={{ height: `${tableHeight}px`, minHeight: '100px', maxHeight: '80%' }}
-                  className="overflow-hidden"
+                  ref={tablePanelRef}
+                  style={{ height: `${tableHeight}px` }}
+                  className="overflow-hidden flex-shrink-0"
                 >
                   <DataTable
-                    data={tableData}
+                    data={tableRows}
                     columns={displayColumns}
                     stringColumns={stringColumns}
+                    heading={hasActiveSelection ? 'Selected Data' : 'All Data'}
+                    capNote={tableCapNote}
                   />
                 </div>
               </>

--- a/App.tsx
+++ b/App.tsx
@@ -450,6 +450,18 @@ const App: React.FC = () => {
     }
   };
 
+  // If the panel is hidden mid-drag (e.g. ESC clears the selection while the
+  // toggle is off), the divider unmounts and its pointerup/pointercancel
+  // never fire, which would leave the global drag styles (user-select /
+  // cursor) stuck. Reset them whenever the panel goes away during a drag.
+  useEffect(() => {
+    if (!tableVisible && dividerDragRef.current) {
+      dividerDragRef.current = null;
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+    }
+  }, [tableVisible]);
+
   // Global loading indicator — visible in both empty and main views
   const loadingPill = isRecalculating && (
     <div className="fixed top-4 right-4 z-50 px-4 py-2 bg-brand-primary text-white text-sm font-semibold rounded-full shadow-lg animate-pulse pointer-events-none">

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -22,6 +22,8 @@ interface ControlPanelProps {
   setFilterMode: (mode: FilterMode) => void;
   showHistograms: boolean;
   setShowHistograms: (show: boolean) => void;
+  showDataTable: boolean;
+  setShowDataTable: (show: boolean) => void;
   useUniformLogBins: boolean;
   setUseUniformLogBins: (useUniform: boolean) => void;
   globalLogScale: boolean;
@@ -53,6 +55,8 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   setFilterMode,
   showHistograms,
   setShowHistograms,
+  showDataTable,
+  setShowDataTable,
   useUniformLogBins,
   setUseUniformLogBins,
   globalLogScale,
@@ -325,6 +329,16 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
               id="globalLogScale"
               checked={globalLogScale}
               onChange={(e) => onToggleGlobalLogScale(e.target.checked)}
+              className="h-5 w-5 rounded text-brand-primary focus:ring-brand-secondary"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <label htmlFor="showDataTable" className="font-semibold text-gray-700">Show Data Table</label>
+            <input
+              type="checkbox"
+              id="showDataTable"
+              checked={showDataTable}
+              onChange={(e) => setShowDataTable(e.target.checked)}
               className="h-5 w-5 rounded text-brand-primary focus:ring-brand-secondary"
             />
           </div>

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -6,6 +6,10 @@ interface DataTableProps {
   columns: Column[];
   stringColumns: string[];
   maxRows?: number;
+  /** Panel heading; defaults to "Selected Data" for selection views. */
+  heading?: string;
+  /** Optional "Showing first X of N rows" note when the data was capped. */
+  capNote?: string | null;
 }
 
 type SortConfig = {
@@ -17,9 +21,11 @@ export const DataTable: React.FC<DataTableProps> = ({
   data,
   columns,
   stringColumns,
-  maxRows = 20
+  maxRows = 20,
+  heading = 'Selected Data',
+  capNote = null
 }) => {
-  const [currentPage, setCurrentPage] = useState(0);
+  const [rawPage, setCurrentPage] = useState(0);
     const [sortConfig, setSortConfig] = useState<SortConfig>(null);
 
   const visibleColumns = columns.filter(c => c.visible);
@@ -55,6 +61,10 @@ export const DataTable: React.FC<DataTableProps> = ({
 
     const totalRows = sortedData.length;
   const totalPages = Math.ceil(totalRows / maxRows);
+  // Clamp: the dataset can shrink under us (e.g. switching from the full
+  // dataset to a small selection), which would otherwise strand us on an
+  // out-of-range page.
+  const currentPage = Math.min(rawPage, Math.max(0, totalPages - 1));
   const startIdx = currentPage * maxRows;
   const endIdx = Math.min(startIdx + maxRows, totalRows);
     const pageData = sortedData.slice(startIdx, endIdx);
@@ -75,13 +85,18 @@ export const DataTable: React.FC<DataTableProps> = ({
   return (
       <div className="bg-white border-t border-gray-200 p-4 h-full flex flex-col overflow-hidden">
           <div className="flex justify-between items-center mb-3 flex-shrink-0">
-        <h3 className="text-lg font-semibold text-gray-800">
-          Selected Data ({totalRows.toLocaleString()} row{totalRows !== 1 ? 's' : ''})
-        </h3>
+        <div className="flex items-baseline space-x-3">
+          <h3 className="text-lg font-semibold text-gray-800">
+            {heading} ({totalRows.toLocaleString()} row{totalRows !== 1 ? 's' : ''})
+          </h3>
+          {capNote && (
+            <span className="text-sm text-amber-700">{capNote}</span>
+          )}
+        </div>
         {totalPages > 1 && (
           <div className="flex items-center space-x-2">
             <button
-              onClick={() => setCurrentPage(p => Math.max(0, p - 1))}
+              onClick={() => setCurrentPage(Math.max(0, currentPage - 1))}
               disabled={currentPage === 0}
               className="px-3 py-1 bg-gray-200 text-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-300"
             >
@@ -91,7 +106,7 @@ export const DataTable: React.FC<DataTableProps> = ({
               Page {currentPage + 1} of {totalPages}
             </span>
             <button
-              onClick={() => setCurrentPage(p => Math.min(totalPages - 1, p + 1))}
+              onClick={() => setCurrentPage(Math.min(totalPages - 1, currentPage + 1))}
               disabled={currentPage >= totalPages - 1}
               className="px-3 py-1 bg-gray-200 text-gray-700 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-300"
             >

--- a/src/test/tableLayout.test.ts
+++ b/src/test/tableLayout.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampTableHeight,
+  computeDragHeight,
+  isTableVisible,
+  capTableRows,
+  TABLE_MIN_HEIGHT,
+  TABLE_MAX_CONTAINER_FRACTION,
+  TABLE_ROW_CAP,
+} from '../utils/tableLayout';
+
+describe('clampTableHeight (issue #49)', () => {
+  it('passes through heights inside the allowed range', () => {
+    expect(clampTableHeight(300, 1000)).toBe(300);
+    expect(clampTableHeight(TABLE_MIN_HEIGHT, 1000)).toBe(TABLE_MIN_HEIGHT);
+  });
+
+  it('clamps below the minimum to TABLE_MIN_HEIGHT', () => {
+    expect(clampTableHeight(0, 1000)).toBe(TABLE_MIN_HEIGHT);
+    expect(clampTableHeight(-500, 1000)).toBe(TABLE_MIN_HEIGHT);
+    expect(clampTableHeight(TABLE_MIN_HEIGHT - 1, 1000)).toBe(TABLE_MIN_HEIGHT);
+  });
+
+  it('clamps above the maximum to 70% of the container', () => {
+    const container = 1000;
+    const expectedMax = Math.floor(container * TABLE_MAX_CONTAINER_FRACTION);
+    expect(clampTableHeight(5000, container)).toBe(expectedMax);
+    expect(clampTableHeight(expectedMax + 1, container)).toBe(expectedMax);
+  });
+
+  it('never collapses below the minimum, even in a tiny container', () => {
+    // 70% of 50px is below the minimum; the minimum wins.
+    expect(clampTableHeight(300, 50)).toBe(TABLE_MIN_HEIGHT);
+    expect(clampTableHeight(10, 50)).toBe(TABLE_MIN_HEIGHT);
+  });
+
+  it('rounds fractional pointer-derived heights to whole pixels', () => {
+    expect(clampTableHeight(300.6, 1000)).toBe(301);
+    expect(clampTableHeight(300.4, 1000)).toBe(300);
+  });
+});
+
+describe('computeDragHeight (issue #49)', () => {
+  it('grows the table when the pointer moves up', () => {
+    // Anchor: height 300, pointer at y=500. Pointer moves up to y=400.
+    expect(computeDragHeight(300, 500, 400)).toBe(400);
+  });
+
+  it('shrinks the table when the pointer moves down', () => {
+    expect(computeDragHeight(300, 500, 600)).toBe(200);
+  });
+
+  it('returns the anchor height when the pointer has not moved', () => {
+    expect(computeDragHeight(300, 500, 500)).toBe(300);
+  });
+
+  it('is a pure function of the absolute pointer position (no drift)', () => {
+    // Simulate a wander: down 200, up 300, back to 80px above the start.
+    // Only the final pointer position matters — intermediate moves cannot
+    // accumulate error the way incremental-delta implementations do.
+    const startHeight = 250;
+    const startY = 600;
+    const path = [700, 650, 400, 520];
+    let height = 0;
+    for (const y of path) {
+      height = computeDragHeight(startHeight, startY, y);
+    }
+    expect(height).toBe(computeDragHeight(startHeight, startY, 520));
+    expect(height).toBe(330);
+  });
+});
+
+describe('isTableVisible (issue #56 visibility matrix)', () => {
+  it('toggle OFF + no selection -> hidden', () => {
+    expect(isTableVisible(false, false)).toBe(false);
+  });
+
+  it('toggle OFF + selection -> shown (selection auto-shows the table)', () => {
+    expect(isTableVisible(false, true)).toBe(true);
+  });
+
+  it('toggle ON + no selection -> shown (full dataset)', () => {
+    expect(isTableVisible(true, false)).toBe(true);
+  });
+
+  it('toggle ON + selection -> shown (selected rows)', () => {
+    expect(isTableVisible(true, true)).toBe(true);
+  });
+});
+
+describe('capTableRows (issue #56 full-dataset cap)', () => {
+  const makeRows = (n: number) => Array.from({ length: n }, (_, i) => ({ __id: i }));
+
+  it('returns all rows and no note when at or below the cap', () => {
+    const under = makeRows(10);
+    expect(capTableRows(under)).toEqual({ rows: under, capNote: null });
+
+    const exact = makeRows(TABLE_ROW_CAP);
+    const result = capTableRows(exact);
+    expect(result.rows).toHaveLength(TABLE_ROW_CAP);
+    expect(result.capNote).toBeNull();
+  });
+
+  it('caps rows above the limit and reports the counts', () => {
+    const { rows, capNote } = capTableRows(makeRows(30000));
+    expect(rows).toHaveLength(TABLE_ROW_CAP);
+    expect(rows[0].__id).toBe(0);
+    expect(rows[TABLE_ROW_CAP - 1].__id).toBe(TABLE_ROW_CAP - 1);
+    expect(capNote).toBe('Showing first 1,000 of 30,000 rows');
+  });
+
+  it('caps at exactly one row over the limit', () => {
+    const { rows, capNote } = capTableRows(makeRows(TABLE_ROW_CAP + 1));
+    expect(rows).toHaveLength(TABLE_ROW_CAP);
+    expect(capNote).toBe('Showing first 1,000 of 1,001 rows');
+  });
+
+  it('handles empty datasets', () => {
+    expect(capTableRows([])).toEqual({ rows: [], capNote: null });
+  });
+
+  it('respects a custom cap', () => {
+    const { rows, capNote } = capTableRows(makeRows(5), 3);
+    expect(rows).toHaveLength(3);
+    expect(capNote).toBe('Showing first 3 of 5 rows');
+  });
+});

--- a/src/utils/tableLayout.ts
+++ b/src/utils/tableLayout.ts
@@ -1,0 +1,72 @@
+// Pure logic for the resizable data-table panel (issues #49 and #56).
+// Kept free of DOM/React so it can be unit-tested directly.
+
+/** Minimum height of the table panel in px. */
+export const TABLE_MIN_HEIGHT = 80;
+
+/** The table panel may take up at most this fraction of the main area. */
+export const TABLE_MAX_CONTAINER_FRACTION = 0.7;
+
+/** Max rows shown when displaying the full (unselected) dataset. */
+export const TABLE_ROW_CAP = 1000;
+
+/**
+ * Clamp a desired table height to [TABLE_MIN_HEIGHT, 70% of the container].
+ * If the container is tiny, the minimum wins (the panel never collapses
+ * below TABLE_MIN_HEIGHT, even if that overflows a degenerate container).
+ */
+export function clampTableHeight(desired: number, containerHeight: number): number {
+  const max = Math.max(
+    TABLE_MIN_HEIGHT,
+    Math.floor(containerHeight * TABLE_MAX_CONTAINER_FRACTION)
+  );
+  return Math.min(max, Math.max(TABLE_MIN_HEIGHT, Math.round(desired)));
+}
+
+/**
+ * Height during a divider drag, computed from the drag-start anchor and the
+ * absolute pointer position (never from incremental deltas, which drift).
+ * Dragging the divider up (smaller clientY) grows the table.
+ */
+export function computeDragHeight(
+  startHeight: number,
+  startY: number,
+  currentY: number
+): number {
+  return startHeight + (startY - currentY);
+}
+
+/**
+ * Visibility matrix for the table panel (issue #56):
+ *
+ * | toggle | selection | table  |
+ * |--------|-----------|--------|
+ * | off    | none      | hidden |
+ * | off    | active    | shown  | (selection auto-shows the table — preserved behavior)
+ * | on     | none      | shown  | (full dataset, capped)
+ * | on     | active    | shown  | (selected rows)
+ */
+export function isTableVisible(showTable: boolean, hasSelection: boolean): boolean {
+  return showTable || hasSelection;
+}
+
+export interface CappedRows<T> {
+  rows: T[];
+  /** Human-readable note when rows were capped, otherwise null. */
+  capNote: string | null;
+}
+
+/**
+ * Cap a full-dataset view at `cap` rows with a "Showing first X of N rows"
+ * note. Selection views are never capped (a brush selection is already
+ * bounded by what the user swept).
+ */
+export function capTableRows<T>(rows: T[], cap: number = TABLE_ROW_CAP): CappedRows<T> {
+  if (rows.length <= cap) {
+    return { rows, capNote: null };
+  }
+  return {
+    rows: rows.slice(0, cap),
+    capNote: `Showing first ${cap.toLocaleString('en-US')} of ${rows.length.toLocaleString('en-US')} rows`,
+  };
+}


### PR DESCRIPTION
Closes #49
Closes #56

## Part 1 — #49: divider drag defects found and fixed

Reproduced by reading the B3 drag implementation in `App.tsx` and then driving the built app headlessly (Chromium + Playwright). Four distinct defects, each mapping to a reported symptom:

1. **Jump / dead zone at drag start (stale anchor).** The drag anchor was `tableHeight` React state, but the rendered height could differ: the table wrapper was a default `flex-shrink: 1` flex child with `maxHeight: '80%'`, so once state exceeded what layout allowed, the visual height was capped while state kept growing. The next drag then started from the state value, not the visible height — the panel jumped, and drags through the "capped" range felt dead. **Fix:** the wrapper is now `flex-shrink-0` with a single JS clamp, and each drag anchors to the panel's *rendered* height (`getBoundingClientRect`) so state/layout can never disagree at drag start.

2. **Stuck drag (no pointer capture).** Document-level `mousemove`/`mouseup` listeners miss a mouseup outside the window, leaving the app in drag mode with `user-select: none` stuck on. **Fix:** pointer events with `setPointerCapture` on the divider (plus `pointercancel` handling and `touch-action: none` for touch/pen), so the drag tracks wherever the pointer goes and always ends cleanly.

3. **Per-mousemove React re-render + forced layout.** Every move called `setTableHeight` (re-rendering `App` and the entire non-memoized `ScatterPlotMatrix` component tree — the canvases themselves don't repaint since the main draw effect's deps are stable, but the n² cells of JSX re-rendered per move) and ran `document.querySelector('main').getBoundingClientRect()` (synchronous forced layout per move). **Fix:** during the drag the height is written directly to the panel's DOM style and the container height is captured once at drag start; React state is committed exactly once on pointerup. The matrix container just shrinks with overflow scroll — verified no canvas repaint and no matrix re-render during resize.

4. **Cursor flicker.** `cursor: row-resize` only applied over the 12px handle. **Fix:** body gets `cursor: row-resize` + `user-select: none` for the duration of the drag.

Height is computed from the drag-start anchor + absolute pointer position (`computeDragHeight`, pure) and clamped to **80px … 70% of the main area** (`clampTableHeight`, pure), replacing the old inconsistent triple clamp (JS 100px/80%, CSS `minHeight: 100px`, CSS `maxHeight: 80%`).

## Part 2 — #56: data table available via toggle

- New **"Show Data Table"** checkbox in the control panel, default **off** (preserves the current default look). State only for now — no persistence infra exists yet.
- **Toggle on + selection** → selected rows (current behavior), heading "Selected Data".
- **Toggle on + no selection** → full dataset capped at the **first 1,000 rows** with a clear *"Showing first 1,000 of N rows"* note, heading "All Data". No virtualization in this PR — with the 1,000-row cap the paginated table (20 rows/page) stays snappy; virtualization is a follow-up if we ever want to show everything.
- **Toggle off + selection** → the table still auto-appears, exactly as today, so the feature stays discoverable; **ESC/Clear** hides it again. (With the toggle on, ESC returns to the full-dataset view instead.)
- The resizable divider works identically in all visible states.
- `DataTable` also now clamps its page index, so switching from the full dataset (50 pages) to a small selection can't strand pagination on an out-of-range page.

Pure logic (clamp, drag height, 4-way visibility matrix, row cap + note) lives in `src/utils/tableLayout.ts`; `App.tsx` changes are kept to the B3 block + one memo + two props to avoid conflicts with the in-flight color-by and zoom PRs.

## Testing

- `npm run typecheck` clean, `npm run test:run` green (120 tests / 14 files, including new `src/test/tableLayout.test.ts`: height clamp min/max/tiny-container, absolute-anchor no-drift drag math, all 4 toggle×selection visibility combinations, cap/count message incl. boundary at 1,000/1,001), `npm run build` OK.
- End-to-end in headless Chromium against the production build (16/16 checks): default hidden; toggle shows "All Data (150 rows)"; drag tracks the pointer exactly (+150 requested → +150 observed) including wandering far off the handle; no jump on release or on the next drag after hitting a clamp; max clamp lands on 70% of main (585px observed vs 585px expected) and min on 80px; brush with toggle off auto-shows "Selected Data"; ESC hides it; 2,500-row CSV shows "Showing first 1,000 of 2,500 rows"; selection overrides the cap note; ESC with toggle on returns to the capped full-dataset view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Show Data Table” toggle in the control panel.
  * When a selection exists, the table shows only selected rows; otherwise it can reveal the full dataset with clearer headings.
  * Added a cap notice for the full dataset when results are limited.
* **Bug Fixes**
  * Improved table resizing responsiveness using pointer-based dragging.
  * Fixed pagination edge cases to keep page navigation within valid bounds as data changes.
* **Tests**
  * Added unit tests for table layout, capping, visibility, and drag-height calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->