### PR TITLE
feat: fluid tile zoom — Ctrl+wheel with CSS-scale gesture and debounced re-render (closes #57)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import type { FileHistoryEntry } from './src/utils/fileHistory';
 import { fetchCsvFromUrl, getDataUrlFromQuery } from './src/utils/urlLoader';
 import { UrlInput } from './components/UrlInput';
 import { computePCA, projectPCA, PCA_COLUMN_NAMES } from './src/utils/pca';
+import { stepCellSize } from './src/utils/zoomUtils';
 import type { PCAVarianceEntry } from './components/ControlPanel';
 
 const MAX_INITIAL_RENDER_POINTS = 15_000;
@@ -313,6 +314,23 @@ const App: React.FC = () => {
     setShowColumnGroups(prev => !prev);
   };
 
+  // Issue #57: +/- zoom buttons and keyboard shortcuts step cellSize ~20%.
+  // Wheel-gesture commits arrive through the same setCellSize, so the
+  // ControlPanel slider stays in sync (cellSize is the single source of truth).
+  const handleZoomStep = useCallback((direction: 1 | -1) => {
+    setCellSize(prev => stepCellSize(prev, direction));
+  }, []);
+
+  const handleMatrixKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === '+' || e.key === '=') {
+      e.preventDefault();
+      handleZoomStep(1);
+    } else if (e.key === '-' || e.key === '_') {
+      e.preventDefault();
+      handleZoomStep(-1);
+    }
+  }, [handleZoomStep]);
+
   const handleRenderComplete = useCallback(() => {
     setIsRecalculating(false);
     setRenderProgress(null);
@@ -524,12 +542,36 @@ const App: React.FC = () => {
             )}
 
             <div
-              className="p-4 overflow-auto"
+              className="p-4 overflow-auto focus:outline-none"
               style={{
                 flex: tableData.length > 0 ? '1 1 auto' : '1 1 0',
                 minHeight: 0
               }}
+              tabIndex={0}
+              onKeyDown={handleMatrixKeyDown}
             >
+              {/* Issue #57: zoom controls — sticky so they stay visible while
+                  the (potentially huge) matrix scrolls beneath them. */}
+              <div className="sticky top-0 left-0 z-20 mb-2 flex w-fit items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => handleZoomStep(-1)}
+                  aria-label="Zoom out"
+                  title="Zoom out (-)  ·  Ctrl+scroll to zoom"
+                  className="w-7 h-7 flex items-center justify-center rounded border border-gray-300 bg-white/90 text-gray-700 shadow-sm hover:bg-gray-200 font-bold leading-none select-none"
+                >
+                  −
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleZoomStep(1)}
+                  aria-label="Zoom in"
+                  title="Zoom in (+)  ·  Ctrl+scroll to zoom"
+                  className="w-7 h-7 flex items-center justify-center rounded border border-gray-300 bg-white/90 text-gray-700 shadow-sm hover:bg-gray-200 font-bold leading-none select-none"
+                >
+                  +
+                </button>
+              </div>
               <ScatterPlotMatrix
                 data={data}
                 columns={displayColumns}
@@ -543,6 +585,7 @@ const App: React.FC = () => {
                 onPointHover={handlePointHover}
                 onPointLeave={handlePointLeave}
                 cellSize={cellSize}
+                onCellSizeChange={setCellSize}
                 onRenderComplete={handleRenderComplete}
                 onRenderProgress={handleRenderProgress}
               />

--- a/App.tsx
+++ b/App.tsx
@@ -322,6 +322,8 @@ const App: React.FC = () => {
   }, []);
 
   const handleMatrixKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Don't hijack browser shortcuts (e.g. Ctrl/Cmd +/- page zoom) or Alt combos.
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
     if (e.key === '+' || e.key === '=') {
       e.preventDefault();
       handleZoomStep(1);
@@ -542,7 +544,7 @@ const App: React.FC = () => {
             )}
 
             <div
-              className="p-4 overflow-auto focus:outline-none"
+              className="p-4 overflow-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-primary"
               style={{
                 flex: tableData.length > 0 ? '1 1 auto' : '1 1 0',
                 minHeight: 0

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -336,7 +336,7 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
             <input
               type="range"
               id="cellSize"
-              min={80}
+              min={60}
               max={400}
               step={10}
               value={cellSize}

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -6,6 +6,7 @@ import { mapVisibleColumns } from '../src/utils/columnUtils';
 import { filterData } from '../src/utils/dataUtils';
 import { computeSelectedStateHash, createSpatialGrid, getPointsInBrush } from '../src/utils/selectionUtils';
 import { ImageDataLRU, totalSnapshotBytes } from '../src/utils/imageDataCache';
+import { createZoomGestureController, isZoomWheelEvent } from '../src/utils/zoomUtils';
 
 interface ScatterPlotMatrixProps {
   data: DataPoint[];
@@ -20,6 +21,8 @@ interface ScatterPlotMatrixProps {
   onPointHover: (content: string, event: MouseEvent) => void;
   onPointLeave: () => void;
   cellSize?: number;
+  /** Commit callback for the fluid Ctrl/Cmd+wheel zoom gesture (issue #57). */
+  onCellSizeChange?: (size: number) => void;
   onRenderComplete?: () => void;
   onRenderProgress?: (cellsDone: number, cellsTotal: number) => void;
 }
@@ -127,10 +130,12 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   onPointHover,
   onPointLeave,
   cellSize = 150,
+  onCellSizeChange,
   onRenderComplete,
   onRenderProgress,
 }) => {
   const ref = useRef<SVGSVGElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
   const canvasContainerRef = useRef<HTMLDivElement>(null);
   const canvasElementsRef = useRef<Map<string, HTMLCanvasElement>>(new Map());
   const canvasRenderKeyRef = useRef<Map<string, string>>(new Map());
@@ -149,6 +154,61 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   });
   const size = cellSize;
   const padding = 20;
+
+  // --- Fluid zoom gesture (issue #57) -------------------------------------
+  // While Ctrl/Cmd+wheel is in flight, the already-painted matrix is scaled
+  // with a CSS transform only (blurry but cheap — no canvas repaints). The
+  // debounced commit then updates cellSize through the normal pipeline for a
+  // single crisp re-render. `zoomGesture` is deliberately NOT a dependency of
+  // the paint effect below, so per-tick updates never retrigger painting.
+  const [zoomGesture, setZoomGesture] = useState<{ scale: number; origin: string } | null>(null);
+  const cellSizeRef = useRef(cellSize);
+  const onCellSizeChangeRef = useRef(onCellSizeChange);
+  useEffect(() => {
+    cellSizeRef.current = cellSize;
+    onCellSizeChangeRef.current = onCellSizeChange;
+  }, [cellSize, onCellSizeChange]);
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+
+    // transform-origin is captured at gesture start (near the cursor) and
+    // held for the rest of the gesture so the preview doesn't jump around.
+    let gestureOrigin = '0px 0px';
+
+    const controller = createZoomGestureController({
+      getCellSize: () => cellSizeRef.current,
+      onScaleChange: scale => setZoomGesture({ scale, origin: gestureOrigin }),
+      onCommit: nextCellSize => {
+        setZoomGesture(null);
+        if (nextCellSize !== cellSizeRef.current) {
+          onCellSizeChangeRef.current?.(nextCellSize);
+        }
+      },
+    });
+
+    const handleWheel = (event: WheelEvent) => {
+      // Plain wheel keeps normal scrolling; only Ctrl/Cmd+wheel zooms.
+      if (!isZoomWheelEvent(event)) return;
+      event.preventDefault(); // stop browser page-zoom
+      if (!controller.isActive()) {
+        // Scale is still 1 here, so the rect is untransformed.
+        const rect = el.getBoundingClientRect();
+        gestureOrigin = `${event.clientX - rect.left}px ${event.clientY - rect.top}px`;
+      }
+      controller.wheel(event.deltaY);
+    };
+
+    // Native listener: React attaches wheel handlers passively, which would
+    // make preventDefault() a no-op.
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', handleWheel);
+      controller.cancel();
+    };
+  }, []);
+  // -------------------------------------------------------------------------
 
   // Tooltip positioning constants
   const TOOLTIP_WIDTH = 200;
@@ -1004,7 +1064,15 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   }, [data, columns, onBrush, filteredData, selectedData, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, onRenderComplete, onRenderProgress]);
 
   return (
-    <div className="w-full h-full relative">
+    <div
+      ref={rootRef}
+      className="w-full h-full relative"
+      style={zoomGesture ? {
+        transform: `scale(${zoomGesture.scale})`,
+        transformOrigin: zoomGesture.origin,
+        willChange: 'transform',
+      } : undefined}
+    >
       <div
         style={{
           position: 'absolute',

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -6,7 +6,7 @@ import { mapVisibleColumns } from '../src/utils/columnUtils';
 import { filterData } from '../src/utils/dataUtils';
 import { computeSelectedStateHash, createSpatialGrid, getPointsInBrush } from '../src/utils/selectionUtils';
 import { ImageDataLRU, totalSnapshotBytes } from '../src/utils/imageDataCache';
-import { createZoomGestureController, isZoomWheelEvent } from '../src/utils/zoomUtils';
+import { createZoomGestureController, isZoomWheelEvent, normalizeWheelDelta } from '../src/utils/zoomUtils';
 
 interface ScatterPlotMatrixProps {
   data: DataPoint[];
@@ -189,6 +189,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     });
 
     const handleWheel = (event: WheelEvent) => {
+      // Zoom is disabled without a commit callback — leave the browser's
+      // default Ctrl/Cmd+wheel behavior (page zoom) alone in that case.
+      if (!onCellSizeChangeRef.current) return;
       // Plain wheel keeps normal scrolling; only Ctrl/Cmd+wheel zooms.
       if (!isZoomWheelEvent(event)) return;
       event.preventDefault(); // stop browser page-zoom
@@ -197,7 +200,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         const rect = el.getBoundingClientRect();
         gestureOrigin = `${event.clientX - rect.left}px ${event.clientY - rect.top}px`;
       }
-      controller.wheel(event.deltaY);
+      // deltaY may be in lines/pages depending on the device (deltaMode).
+      controller.wheel(normalizeWheelDelta(event.deltaY, event.deltaMode));
     };
 
     // Native listener: React attaches wheel handlers passively, which would

--- a/src/test/fluidZoom.test.tsx
+++ b/src/test/fluidZoom.test.tsx
@@ -5,7 +5,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { ScatterPlotMatrix } from '../../components/ScatterPlotMatrix';
 import type { Column, DataPoint } from '../../types';
-import { accumulateWheelZoom, commitZoom } from '../utils/zoomUtils';
+import { accumulateWheelZoom, commitZoom, normalizeWheelDelta } from '../utils/zoomUtils';
 
 const makeProps = (overrides: Partial<React.ComponentProps<typeof ScatterPlotMatrix>> = {}) => {
     const data: DataPoint[] = Array.from({ length: 20 }, (_, i) => ({
@@ -66,6 +66,25 @@ describe('fluid zoom gesture (issue #57)', () => {
         expect(root.style.transform).toBe('');
         await new Promise(resolve => setTimeout(resolve, 300));
         expect(onCellSizeChange).not.toHaveBeenCalled();
+    });
+
+    it('leaves Ctrl+wheel alone (browser page-zoom) when onCellSizeChange is not provided', () => {
+        const { root } = renderMatrix(); // no onCellSizeChange prop
+
+        const notPrevented = dispatchWheel(root, { deltaY: -100, ctrlKey: true });
+
+        expect(notPrevented).toBe(true); // default browser behavior preserved
+        expect(root.style.transform).toBe('');
+    });
+
+    it('normalizes line-mode wheel deltas (deltaMode 1) so zoom sensitivity matches pixel mode', () => {
+        const { root } = renderMatrix({ onCellSizeChange: vi.fn() });
+
+        // Firefox-style mouse wheel notch: 3 lines, not 3 pixels.
+        dispatchWheel(root, { deltaY: -3, deltaMode: 1, ctrlKey: true });
+
+        const expectedScale = accumulateWheelZoom(1, normalizeWheelDelta(-3, 1), 150);
+        expect(root.style.transform).toBe(`scale(${expectedScale})`);
     });
 
     it('Ctrl+wheel applies a CSS scale preview and prevents browser page-zoom', () => {

--- a/src/test/fluidZoom.test.tsx
+++ b/src/test/fluidZoom.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { ScatterPlotMatrix } from '../../components/ScatterPlotMatrix';
+import type { Column, DataPoint } from '../../types';
+import { accumulateWheelZoom, commitZoom } from '../utils/zoomUtils';
+
+const makeProps = (overrides: Partial<React.ComponentProps<typeof ScatterPlotMatrix>> = {}) => {
+    const data: DataPoint[] = Array.from({ length: 20 }, (_, i) => ({
+        __id: i,
+        a: i,
+        b: 20 - i,
+    }));
+    const columns: Column[] = [
+        { name: 'a', scale: 'linear', visible: true },
+        { name: 'b', scale: 'linear', visible: true },
+    ];
+    return {
+        data,
+        columns,
+        onColumnReorder: () => { },
+        brushSelection: null,
+        onBrush: () => { },
+        filterMode: 'highlight' as const,
+        showHistograms: false,
+        useUniformLogBins: false,
+        labelColumn: null,
+        onPointHover: () => { },
+        onPointLeave: () => { },
+        cellSize: 150,
+        ...overrides,
+    };
+};
+
+const renderMatrix = (overrides: Partial<React.ComponentProps<typeof ScatterPlotMatrix>> = {}) => {
+    const props = makeProps(overrides);
+    const utils = render(
+        <DndProvider backend={HTML5Backend}>
+            <ScatterPlotMatrix {...props} />
+        </DndProvider>
+    );
+    const root = utils.container.firstElementChild as HTMLElement;
+    return { ...utils, root };
+};
+
+const dispatchWheel = (el: HTMLElement, init: WheelEventInit): boolean => {
+    let notPrevented = true;
+    act(() => {
+        notPrevented = el.dispatchEvent(
+            new WheelEvent('wheel', { bubbles: true, cancelable: true, ...init })
+        );
+    });
+    return notPrevented;
+};
+
+describe('fluid zoom gesture (issue #57)', () => {
+    it('plain wheel scrolls normally: no transform, no preventDefault, no commit', async () => {
+        const onCellSizeChange = vi.fn();
+        const { root } = renderMatrix({ onCellSizeChange });
+
+        const notPrevented = dispatchWheel(root, { deltaY: -100 });
+
+        expect(notPrevented).toBe(true); // browser scrolling untouched
+        expect(root.style.transform).toBe('');
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(onCellSizeChange).not.toHaveBeenCalled();
+    });
+
+    it('Ctrl+wheel applies a CSS scale preview and prevents browser page-zoom', () => {
+        const { root } = renderMatrix({ onCellSizeChange: vi.fn() });
+
+        const notPrevented = dispatchWheel(root, { deltaY: -100, ctrlKey: true });
+
+        expect(notPrevented).toBe(false); // preventDefault() was called
+        const expectedScale = accumulateWheelZoom(1, -100, 150);
+        expect(root.style.transform).toBe(`scale(${expectedScale})`);
+    });
+
+    it('commits round(cellSize * scale) after the debounce and resets the transform', async () => {
+        const onCellSizeChange = vi.fn();
+        const { root } = renderMatrix({ onCellSizeChange });
+
+        dispatchWheel(root, { deltaY: -100, ctrlKey: true });
+        dispatchWheel(root, { deltaY: -100, ctrlKey: true });
+        expect(root.style.transform).not.toBe('');
+
+        const expectedScale = accumulateWheelZoom(
+            accumulateWheelZoom(1, -100, 150), -100, 150
+        );
+        await waitFor(() =>
+            expect(onCellSizeChange).toHaveBeenCalledWith(commitZoom(150, expectedScale))
+        );
+        expect(onCellSizeChange).toHaveBeenCalledTimes(1);
+        expect(root.style.transform).toBe(''); // preview reset on commit
+    });
+
+    it('the gesture never retriggers the paint pipeline (CSS transform only)', async () => {
+        const onCellSizeChange = vi.fn();
+        const onRenderComplete = vi.fn();
+        const { root } = renderMatrix({ onCellSizeChange, onRenderComplete });
+
+        // Let the initial mount render finish.
+        await waitFor(() => expect(onRenderComplete).toHaveBeenCalledTimes(1));
+
+        // A multi-tick gesture: transient state updates must not re-run the
+        // paint effect (which would call onRenderComplete again) or resize
+        // the canvases.
+        const canvas = root.querySelector('canvas') as HTMLCanvasElement;
+        const widthBefore = canvas.width;
+        dispatchWheel(root, { deltaY: -100, ctrlKey: true });
+        dispatchWheel(root, { deltaY: -50, ctrlKey: true });
+        dispatchWheel(root, { deltaY: 25, ctrlKey: true });
+
+        await waitFor(() => expect(onCellSizeChange).toHaveBeenCalledTimes(1));
+        expect(onRenderComplete).toHaveBeenCalledTimes(1);
+        expect(canvas.width).toBe(widthBefore);
+    });
+});

--- a/src/test/zoomUtils.test.ts
+++ b/src/test/zoomUtils.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  MIN_CELL_SIZE,
+  MAX_CELL_SIZE,
+  ZOOM_COMMIT_DEBOUNCE_MS,
+  ZOOM_STEP_FACTOR,
+  clampCellSize,
+  wheelDeltaToScaleFactor,
+  clampScaleForCellSize,
+  accumulateWheelZoom,
+  commitZoom,
+  stepCellSize,
+  isZoomWheelEvent,
+  createZoomGestureController,
+} from '../utils/zoomUtils';
+
+describe('zoomUtils: pure math', () => {
+  describe('clampCellSize', () => {
+    it('rounds to whole pixels', () => {
+      expect(clampCellSize(150.4)).toBe(150);
+      expect(clampCellSize(150.6)).toBe(151);
+    });
+
+    it('clamps to the allowed range', () => {
+      expect(clampCellSize(1)).toBe(MIN_CELL_SIZE);
+      expect(clampCellSize(10_000)).toBe(MAX_CELL_SIZE);
+      expect(clampCellSize(MIN_CELL_SIZE)).toBe(MIN_CELL_SIZE);
+      expect(clampCellSize(MAX_CELL_SIZE)).toBe(MAX_CELL_SIZE);
+    });
+  });
+
+  describe('wheelDeltaToScaleFactor', () => {
+    it('zooms in on scroll up (negative deltaY)', () => {
+      expect(wheelDeltaToScaleFactor(-100)).toBeGreaterThan(1);
+    });
+
+    it('zooms out on scroll down (positive deltaY)', () => {
+      expect(wheelDeltaToScaleFactor(100)).toBeLessThan(1);
+      expect(wheelDeltaToScaleFactor(100)).toBeGreaterThan(0);
+    });
+
+    it('is identity for deltaY 0 and symmetric for +/- deltas', () => {
+      expect(wheelDeltaToScaleFactor(0)).toBe(1);
+      expect(wheelDeltaToScaleFactor(-100) * wheelDeltaToScaleFactor(100)).toBeCloseTo(1, 12);
+    });
+  });
+
+  describe('accumulateWheelZoom / clampScaleForCellSize', () => {
+    it('accumulates multiplicatively across ticks', () => {
+      const oneTick = accumulateWheelZoom(1, -100, 150);
+      const twoTicks = accumulateWheelZoom(oneTick, -100, 150);
+      expect(twoTicks).toBeCloseTo(oneTick * oneTick, 12);
+    });
+
+    it('never lets cellSize * scale exceed MAX_CELL_SIZE', () => {
+      let scale = 1;
+      for (let i = 0; i < 100; i++) scale = accumulateWheelZoom(scale, -500, 150);
+      expect(150 * scale).toBeLessThanOrEqual(MAX_CELL_SIZE + 1e-9);
+    });
+
+    it('never lets cellSize * scale fall below MIN_CELL_SIZE', () => {
+      let scale = 1;
+      for (let i = 0; i < 100; i++) scale = accumulateWheelZoom(scale, 500, 150);
+      expect(150 * scale).toBeGreaterThanOrEqual(MIN_CELL_SIZE - 1e-9);
+    });
+
+    it('falls back to a neutral scale for degenerate inputs', () => {
+      expect(clampScaleForCellSize(Number.NaN, 150)).toBe(1);
+      expect(clampScaleForCellSize(2, 0)).toBe(1);
+    });
+  });
+
+  describe('commitZoom', () => {
+    it('commits round(cellSize * scale)', () => {
+      expect(commitZoom(150, 1.221)).toBe(183);
+      expect(commitZoom(150, 1)).toBe(150);
+    });
+
+    it('clamps the committed size', () => {
+      expect(commitZoom(150, 100)).toBe(MAX_CELL_SIZE);
+      expect(commitZoom(150, 0.01)).toBe(MIN_CELL_SIZE);
+    });
+  });
+
+  describe('stepCellSize', () => {
+    it('steps ~20% up and down', () => {
+      expect(stepCellSize(150, 1)).toBe(Math.round(150 * ZOOM_STEP_FACTOR));
+      expect(stepCellSize(150, -1)).toBe(Math.round(150 / ZOOM_STEP_FACTOR));
+    });
+
+    it('clamps at the bounds', () => {
+      expect(stepCellSize(MAX_CELL_SIZE, 1)).toBe(MAX_CELL_SIZE);
+      expect(stepCellSize(MIN_CELL_SIZE, -1)).toBe(MIN_CELL_SIZE);
+    });
+  });
+
+  describe('isZoomWheelEvent (wheel-handler gating)', () => {
+    it('accepts Ctrl+wheel and Cmd+wheel', () => {
+      expect(isZoomWheelEvent({ ctrlKey: true, metaKey: false })).toBe(true);
+      expect(isZoomWheelEvent({ ctrlKey: false, metaKey: true })).toBe(true);
+    });
+
+    it('rejects plain wheel (normal scrolling)', () => {
+      expect(isZoomWheelEvent({ ctrlKey: false, metaKey: false })).toBe(false);
+    });
+  });
+});
+
+describe('zoomUtils: createZoomGestureController (debounced commit)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const makeController = (cellSize = 150) => {
+    const onScaleChange = vi.fn();
+    const onCommit = vi.fn();
+    const controller = createZoomGestureController({
+      getCellSize: () => cellSize,
+      onScaleChange,
+      onCommit,
+    });
+    return { controller, onScaleChange, onCommit };
+  };
+
+  it('reports scale changes immediately but does not commit before the debounce', () => {
+    const { controller, onScaleChange, onCommit } = makeController();
+
+    controller.wheel(-100);
+    expect(onScaleChange).toHaveBeenCalledTimes(1);
+    expect(onScaleChange).toHaveBeenLastCalledWith(wheelDeltaToScaleFactor(-100));
+    expect(controller.isActive()).toBe(true);
+
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS - 1);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the debounce window on every wheel tick', () => {
+    const { controller, onCommit } = makeController();
+
+    controller.wheel(-100);
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS - 50);
+    controller.wheel(-100);
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS - 50);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('commits the accumulated (clamped, rounded) cellSize and resets to idle', () => {
+    const { controller, onCommit } = makeController(150);
+
+    controller.wheel(-100);
+    controller.wheel(-100);
+    const expectedScale = accumulateWheelZoom(
+      accumulateWheelZoom(1, -100, 150),
+      -100,
+      150
+    );
+
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith(commitZoom(150, expectedScale));
+    expect(controller.isActive()).toBe(false);
+    expect(controller.getScale()).toBe(1);
+
+    // No stray second commit later.
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS * 5);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('a follow-up gesture starts fresh from scale 1', () => {
+    const { controller, onCommit } = makeController(150);
+
+    controller.wheel(-100);
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS);
+
+    controller.wheel(-100);
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS);
+
+    expect(onCommit).toHaveBeenCalledTimes(2);
+    // Both gestures had a single identical tick, so identical commit values.
+    expect(onCommit.mock.calls[0][0]).toBe(onCommit.mock.calls[1][0]);
+  });
+
+  it('cancel() aborts the pending commit', () => {
+    const { controller, onCommit } = makeController();
+
+    controller.wheel(-100);
+    controller.cancel();
+    expect(controller.isActive()).toBe(false);
+    expect(controller.getScale()).toBe(1);
+
+    vi.advanceTimersByTime(ZOOM_COMMIT_DEBOUNCE_MS * 2);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/zoomUtils.test.ts
+++ b/src/test/zoomUtils.test.ts
@@ -5,6 +5,7 @@ import {
   ZOOM_COMMIT_DEBOUNCE_MS,
   ZOOM_STEP_FACTOR,
   clampCellSize,
+  normalizeWheelDelta,
   wheelDeltaToScaleFactor,
   clampScaleForCellSize,
   accumulateWheelZoom,
@@ -26,6 +27,23 @@ describe('zoomUtils: pure math', () => {
       expect(clampCellSize(10_000)).toBe(MAX_CELL_SIZE);
       expect(clampCellSize(MIN_CELL_SIZE)).toBe(MIN_CELL_SIZE);
       expect(clampCellSize(MAX_CELL_SIZE)).toBe(MAX_CELL_SIZE);
+    });
+  });
+
+  describe('normalizeWheelDelta', () => {
+    it('passes pixel-mode deltas (deltaMode 0) through unchanged', () => {
+      expect(normalizeWheelDelta(-100, 0)).toBe(-100);
+      expect(normalizeWheelDelta(42, 0)).toBe(42);
+    });
+
+    it('converts line-mode deltas (deltaMode 1, e.g. Firefox mouse wheel) to pixels', () => {
+      expect(normalizeWheelDelta(-3, 1)).toBe(-48);
+      expect(normalizeWheelDelta(3, 1)).toBe(48);
+    });
+
+    it('converts page-mode deltas (deltaMode 2) to pixels', () => {
+      expect(normalizeWheelDelta(-1, 2)).toBe(-800);
+      expect(normalizeWheelDelta(1, 2)).toBe(800);
     });
   });
 

--- a/src/utils/zoomUtils.ts
+++ b/src/utils/zoomUtils.ts
@@ -1,0 +1,119 @@
+// Fluid tile-zoom logic (issue #57).
+//
+// During a Ctrl/Cmd+wheel gesture the matrix is scaled with a cheap CSS
+// transform (no canvas repaints); when the gesture ends (debounced), the
+// accumulated scale is committed as a new cellSize and the normal render
+// pipeline repaints once at the new size. The pure math lives here so it can
+// be unit-tested without a DOM.
+
+/** Committed cellSize bounds. Kept in sync with the ControlPanel slider. */
+export const MIN_CELL_SIZE = 60;
+export const MAX_CELL_SIZE = 400;
+
+/** Quiet period after the last wheel event before the zoom is committed. */
+export const ZOOM_COMMIT_DEBOUNCE_MS = 200;
+
+/** Step factor for the +/- zoom buttons (~20% per step). */
+export const ZOOM_STEP_FACTOR = 1.2;
+
+/** Wheel sensitivity: scale factor = exp(-deltaY * sensitivity). */
+const WHEEL_ZOOM_SENSITIVITY = 0.002;
+
+/** Clamp (and round) a cell size to the allowed range. */
+export const clampCellSize = (size: number): number =>
+  Math.min(MAX_CELL_SIZE, Math.max(MIN_CELL_SIZE, Math.round(size)));
+
+/**
+ * Convert a wheel deltaY into a multiplicative zoom factor.
+ * Scrolling up (negative deltaY) zooms in (> 1), down zooms out (< 1).
+ * The exponential form makes equal wheel increments compose symmetrically:
+ * +100 then -100 returns exactly to a factor of 1.
+ */
+export const wheelDeltaToScaleFactor = (deltaY: number): number =>
+  Math.exp(-deltaY * WHEEL_ZOOM_SENSITIVITY);
+
+/**
+ * Clamp a transient gesture scale so that `cellSize * scale` stays within
+ * [MIN_CELL_SIZE, MAX_CELL_SIZE]. Keeps the CSS preview honest about what
+ * the commit will produce.
+ */
+export const clampScaleForCellSize = (scale: number, cellSize: number): number => {
+  if (!isFinite(scale) || cellSize <= 0) return 1;
+  return Math.min(MAX_CELL_SIZE / cellSize, Math.max(MIN_CELL_SIZE / cellSize, scale));
+};
+
+/** Accumulate one wheel tick into the running gesture scale (clamped). */
+export const accumulateWheelZoom = (
+  currentScale: number,
+  deltaY: number,
+  cellSize: number
+): number => clampScaleForCellSize(currentScale * wheelDeltaToScaleFactor(deltaY), cellSize);
+
+/** Resolve the gesture: the cellSize to commit for an accumulated scale. */
+export const commitZoom = (cellSize: number, scale: number): number =>
+  clampCellSize(cellSize * scale);
+
+/** One +/- button (or keyboard) step: ~20% in the given direction, clamped. */
+export const stepCellSize = (cellSize: number, direction: 1 | -1): number =>
+  clampCellSize(cellSize * (direction > 0 ? ZOOM_STEP_FACTOR : 1 / ZOOM_STEP_FACTOR));
+
+/** A wheel event is a zoom gesture only with Ctrl (or Cmd on macOS) held. */
+export const isZoomWheelEvent = (event: { ctrlKey: boolean; metaKey: boolean }): boolean =>
+  event.ctrlKey || event.metaKey;
+
+export interface ZoomGestureCallbacks {
+  /** Current committed cell size (read at wheel/commit time, not captured). */
+  getCellSize: () => number;
+  /** Fired on every wheel tick with the new accumulated scale (for the CSS preview). */
+  onScaleChange: (scale: number) => void;
+  /** Fired once, ZOOM_COMMIT_DEBOUNCE_MS after the last wheel tick. */
+  onCommit: (nextCellSize: number) => void;
+}
+
+export interface ZoomGestureController {
+  /** Feed one wheel tick (deltaY) into the gesture. */
+  wheel: (deltaY: number) => void;
+  /** True while a gesture is in flight (commit still pending). */
+  isActive: () => boolean;
+  /** Current accumulated scale (1 when idle). */
+  getScale: () => number;
+  /** Abort the gesture without committing (e.g. on unmount). */
+  cancel: () => void;
+}
+
+/**
+ * Debounced wheel-zoom gesture: accumulates scale across wheel ticks and
+ * commits a single cellSize change after a quiet period.
+ */
+export const createZoomGestureController = (
+  callbacks: ZoomGestureCallbacks,
+  debounceMs: number = ZOOM_COMMIT_DEBOUNCE_MS
+): ZoomGestureController => {
+  let scale = 1;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const commit = () => {
+    timer = null;
+    const nextCellSize = commitZoom(callbacks.getCellSize(), scale);
+    scale = 1;
+    callbacks.onCommit(nextCellSize);
+  };
+
+  return {
+    wheel(deltaY: number) {
+      scale = accumulateWheelZoom(scale, deltaY, callbacks.getCellSize());
+      callbacks.onScaleChange(scale);
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(commit, debounceMs);
+    },
+    isActive: () => timer !== null,
+    getScale: () => scale,
+    cancel() {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      scale = 1;
+    },
+  };
+};

--- a/src/utils/zoomUtils.ts
+++ b/src/utils/zoomUtils.ts
@@ -23,6 +23,22 @@ const WHEEL_ZOOM_SENSITIVITY = 0.002;
 export const clampCellSize = (size: number): number =>
   Math.min(MAX_CELL_SIZE, Math.max(MIN_CELL_SIZE, Math.round(size)));
 
+/** Pixel equivalents for non-pixel WheelEvent.deltaMode values. */
+const LINE_HEIGHT_PX = 16; // DOM_DELTA_LINE
+const PAGE_HEIGHT_PX = 800; // DOM_DELTA_PAGE
+
+/**
+ * Normalize a wheel delta to pixels. Some browsers/devices (notably Firefox
+ * with a traditional mouse wheel) report deltaY in lines (deltaMode 1) or
+ * pages (deltaMode 2); the pixel-tuned sensitivity would make those gestures
+ * nearly inert without conversion.
+ */
+export const normalizeWheelDelta = (deltaY: number, deltaMode: number): number => {
+  if (deltaMode === 1) return deltaY * LINE_HEIGHT_PX;
+  if (deltaMode === 2) return deltaY * PAGE_HEIGHT_PX;
+  return deltaY;
+};
+
 /**
  * Convert a wheel deltaY into a multiplicative zoom factor.
  * Scrolling up (negative deltaY) zooms in (> 1), down zooms out (< 1).


### PR DESCRIPTION
## Summary

Implements #57: fluid zoom of plot tiles on top of the existing `cellSize` slider — a first taste of the pre-rendered-chips technique from #32.

- **Ctrl/Cmd + wheel** over the matrix zooms the tiles. During the gesture the already-painted canvases are scaled with a **CSS `transform: scale()` only** — no canvas repaints, no layout thrash. `preventDefault()` (via a non-passive native listener; React attaches `onWheel` passively) stops browser page-zoom. Plain wheel keeps normal scrolling.
- **Transform origin at the cursor**: captured at gesture start (while the element is still untransformed) and held for the rest of the gesture so the preview zooms toward where you're pointing.
- **Debounced commit**: 200ms after the last wheel tick, `cellSize = round(cellSize × accumulatedScale)` (clamped to 60–400px) is committed through the normal pipeline for a single crisp re-render. The renderKey already includes size, so the ImageData LRU can restore previously-seen sizes instantly.
- **+/− buttons** in a small sticky bar above the matrix (they stay visible while the large matrix scrolls beneath them), stepping ~20% per click, with **`+` / `-` keyboard shortcuts** when the matrix scroll area has focus. Buttons commit immediately — no gesture/debounce.
- **Single source of truth**: all paths (wheel commit, buttons, keys) go through `setCellSize` in `App`, so the ControlPanel slider stays in sync. The slider's min was extended 80 → 60 to match the zoom clamp range. The transient gesture scale lives locally in `ScatterPlotMatrix`.

**Expected behavior note:** the preview is intentionally **blurry during the gesture** — it's a CSS upscale of the existing raster. It resolves to a crisp render on commit. This is the cheap-during/expensive-once tradeoff the issue asks for.

## Implementation

- `src/utils/zoomUtils.ts` — pure, unit-testable logic: wheel-delta → exponential scale factor, scale accumulation clamped so `cellSize × scale` stays in [60, 400], `commitZoom`, `stepCellSize` (~20%), Ctrl/Cmd gating, and `createZoomGestureController` (debounced commit state machine).
- `components/ScatterPlotMatrix.tsx` — new optional `onCellSizeChange` prop; native non-passive `wheel` listener on the matrix root; gesture state (`scale` + `origin`) applied as an inline transform. The gesture state is deliberately **not** a dependency of the paint effect, so per-tick updates never retrigger painting (covered by a test).
- `App.tsx` — sticky zoom button bar, `+`/`-` key handling on the (now focusable) matrix scroll container, `onCellSizeChange={setCellSize}` passed to the matrix. Additive changes only.
- `components/ControlPanel.tsx` — slider `min` 80 → 60.

## Tests

- `src/test/zoomUtils.test.ts` — accumulation/clamp/rounding math, gating (ctrl vs meta vs plain), and the debounce controller under fake timers (reset-on-tick, single commit, fresh follow-up gesture, cancel).
- `src/test/fluidZoom.test.tsx` — jsdom integration: plain wheel is untouched (no transform, not default-prevented, no commit); Ctrl+wheel applies the scale preview and prevents default; debounced commit calls `onCellSizeChange` with `round(cellSize × scale)` and resets the transform; a multi-tick gesture never re-runs the paint pipeline (single `onRenderComplete`, canvas sizes untouched).

## Verification

- `npm run typecheck` clean
- `npm run test:run` — 126/126 passing (15 files)
- `npm run build` OK
- Headless-browser smoke check of the dev server: app renders with the new zoom controls, matrix intact, slider in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added matrix zoom controls with keyboard shortcuts (`+`/`=` and `-`/`_`) plus sticky on-screen buttons.
  * Enabled fluid Ctrl/Cmd + mouse-wheel zoom with live preview during the gesture, committing after a short pause.
  * Reduced the “Plot size” slider minimum to allow tighter layouts.

* **Bug Fixes**
  * Kept zoom state synchronized across keyboard, buttons, wheel-zoom, and matrix-originating changes.
  * Browser wheel scrolling is left untouched unless the fluid zoom gesture is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->