### PR TITLE
fix: accept TSV files in upload picker and drag-drop

### DIFF
--- a/components/FileUpload.tsx
+++ b/components/FileUpload.tsx
@@ -6,20 +6,30 @@ interface FileUploadProps {
   onDataLoaded: (data: string, filename: string) => void;
 }
 
+// MIME types are unreliable for delimited text (TSVs often report an empty
+// type), so acceptance is decided by extension. Parsing auto-detects the
+// delimiter, so any of these route through the same pipeline.
+export const isSupportedDataFile = (name: string): boolean =>
+  /\.(csv|tsv|tab|txt)$/i.test(name);
+
 export const FileUpload: React.FC<FileUploadProps> = ({ onDataLoaded }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const readFile = useCallback((file: File) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const text = e.target?.result;
+      if (typeof text === 'string') {
+        onDataLoaded(text, file.name);
+      }
+    };
+    reader.readAsText(file);
+  }, [onDataLoaded]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const text = e.target?.result;
-        if (typeof text === 'string') {
-          onDataLoaded(text, file.name);
-        }
-      };
-      reader.readAsText(file);
+      readFile(file);
     }
   };
 
@@ -31,19 +41,12 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onDataLoaded }) => {
     event.preventDefault();
     event.stopPropagation();
     const file = event.dataTransfer.files?.[0];
-     if (file && file.type === "text/csv") {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-            const text = e.target?.result;
-            if (typeof text === 'string') {
-                onDataLoaded(text, file.name);
-            }
-        };
-        reader.readAsText(file);
+    if (file && isSupportedDataFile(file.name)) {
+      readFile(file);
     } else {
-        alert("Please drop a valid CSV file.");
+      alert("Please drop a valid CSV or TSV file (.csv, .tsv, .tab, .txt).");
     }
-  }, [onDataLoaded]);
+  }, [readFile]);
 
   const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {
       event.preventDefault();
@@ -63,11 +66,11 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onDataLoaded }) => {
         ref={fileInputRef}
         onChange={handleFileChange}
         className="hidden"
-        accept=".csv"
+        accept=".csv,.tsv,.tab,.txt"
       />
       <UploadIcon className="h-8 w-8 text-gray-400 mb-2" />
       <span className="text-sm font-medium text-gray-600">
-        Click to upload or drag-and-drop CSV
+        Click to upload or drag-and-drop CSV / TSV
       </span>
     </div>
   );

--- a/src/test/fileUpload.test.ts
+++ b/src/test/fileUpload.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isSupportedDataFile } from '../../components/FileUpload';
+
+describe('isSupportedDataFile', () => {
+  it('accepts csv, tsv, tab and txt extensions case-insensitively', () => {
+    expect(isSupportedDataFile('data.csv')).toBe(true);
+    expect(isSupportedDataFile('data.tsv')).toBe(true);
+    expect(isSupportedDataFile('data.tab')).toBe(true);
+    expect(isSupportedDataFile('data.txt')).toBe(true);
+    expect(isSupportedDataFile('DATA.TSV')).toBe(true);
+    expect(isSupportedDataFile('archive.2026.csv')).toBe(true);
+  });
+
+  it('rejects other extensions and extensionless names', () => {
+    expect(isSupportedDataFile('data.xlsx')).toBe(false);
+    expect(isSupportedDataFile('data.json')).toBe(false);
+    expect(isSupportedDataFile('data.csv.gz')).toBe(false);
+    expect(isSupportedDataFile('data')).toBe(false);
+    expect(isSupportedDataFile('csv')).toBe(false);
+  });
+});


### PR DESCRIPTION
Hotfix: TSV parsing already worked (delimiter auto-detect) but the picker's `accept=".csv"` and the drop handler's `file.type === "text/csv"` check blocked TSV files from ever reaching it — TSVs commonly report an empty MIME type, so drops hit the alert. Acceptance is now by extension (.csv/.tsv/.tab/.txt), helper text updated, extension check extracted and unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File uploads and drag-and-drop now accept more delimited text formats, including CSV, TSV, TAB, and TXT variants.
  * Added broader filename checks so supported files are recognized more reliably.

* **Bug Fixes**
  * Improved upload validation to better reject unsupported files.
  * Updated the upload prompt and browser file picker to reflect the expanded file support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->