### PR TITLE
fix: sparse columns (empty leading rows) no longer dropped; missing cells no longer coerce to 0

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ import type { FileHistoryEntry } from './src/utils/fileHistory';
 import { fetchCsvFromUrl, getDataUrlFromQuery } from './src/utils/urlLoader';
 import { UrlInput } from './components/UrlInput';
 import { computePCA, projectPCA, PCA_COLUMN_NAMES } from './src/utils/pca';
+import { detectColumnTypes } from './src/utils/columnTypeUtils';
 import { stepCellSize } from './src/utils/zoomUtils';
 import type { PCAVarianceEntry } from './components/ControlPanel';
 import { clampTableHeight, computeDragHeight, isTableVisible, capTableRows } from './src/utils/tableLayout';
@@ -116,20 +117,19 @@ const App: React.FC = () => {
     const dataWithIds = rawData.map((d, i) => ({ ...d, __id: i }));
     setData(dataWithIds);
 
-    // B4: Detect ALL string columns
-    const allStringCols = (result.meta.fields || []).filter(
-      field => typeof rawData[0][field] === 'string'
-    );
+    // B4 + hotfix: detect column types across ALL rows, not just row 0 —
+    // sparse columns (e.g. PCA scores blank in early rows) parse as null
+    // there and were previously dropped from both lists entirely.
+    const detected = detectColumnTypes(dataWithIds, result.meta.fields);
+    const allStringCols = detected.stringColumns;
     setStringColumns(allStringCols);
     setLabelColumn(allStringCols[0] || null);
 
-    const numericColumns = Object.keys(dataWithIds[0])
-      .filter(key => typeof dataWithIds[0][key] === 'number' && key !== '__id')
-      .map(key => ({
-        name: key,
-        scale: 'linear' as ScaleType,
-        visible: true,
-      }));
+    const numericColumns = detected.numericColumns.map(key => ({
+      name: key,
+      scale: 'linear' as ScaleType,
+      visible: true,
+    }));
 
     // Batch 3: Auto-limit columns on large load
     const rows = dataWithIds.length;

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -6,6 +6,7 @@ import { mapVisibleColumns } from '../src/utils/columnUtils';
 import { filterData } from '../src/utils/dataUtils';
 import { computeSelectedStateHash, createSpatialGrid, getPointsInBrush } from '../src/utils/selectionUtils';
 import { ImageDataLRU, totalSnapshotBytes } from '../src/utils/imageDataCache';
+import { cellValueToNumber } from '../src/utils/cellValueUtils';
 import { MISSING_COLOR, MISSING_SLOT } from '../src/utils/colorUtils';
 import type { ColorState } from '../src/utils/colorUtils';
 import { buildRenderKey } from '../src/utils/renderKeyUtils';
@@ -347,8 +348,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       const dimmedCoords: number[] = [];
 
       for (const d of data) {
-        const x = +d[xCol];
-        const y = +d[yCol];
+        const x = cellValueToNumber(d[xCol]);
+        const y = cellValueToNumber(d[yCol]);
         if (!isFinite(x) || !isFinite(y)) continue;
 
         const screenX = xScale(x);
@@ -392,8 +393,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       data.forEach(d => {
         if (selectedIds.size > 0 && selectedIds.has(d.__id)) return;
 
-        const x = +d[xCol];
-        const y = +d[yCol];
+        const x = cellValueToNumber(d[xCol]);
+        const y = cellValueToNumber(d[yCol]);
         if (!isFinite(x) || !isFinite(y)) return;
 
         const screenX = xScale(x);
@@ -413,8 +414,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       data.forEach(d => {
         if (!selectedIds.has(d.__id)) return;
 
-        const x = +d[xCol];
-        const y = +d[yCol];
+        const x = cellValueToNumber(d[xCol]);
+        const y = cellValueToNumber(d[yCol]);
         if (!isFinite(x) || !isFinite(y)) return;
 
         const screenX = xScale(x);
@@ -597,7 +598,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 
     for (const row of dataForStats) {
       for (const col of visibleColumns) {
-        const value = +row[col.name];
+        const value = cellValueToNumber(row[col.name]);
         if (!isFinite(value)) continue;
         const columnStat = stats.get(col.name);
         if (!columnStat) continue;
@@ -697,7 +698,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 
     const createScale = (c: Column, range: [number, number]) => {
       // Force coercion to number and filter out non-finite values
-      const values = data.map(d => +d[c.name]).filter(isFinite);
+      const values = data.map(d => cellValueToNumber(d[c.name])).filter(isFinite);
       const extent = d3.extent(values);
 
       let domain: [number, number] = [0, 1];
@@ -1072,7 +1073,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           // buckets for rainbow). Bins keep row identity so each row lands
           // in its color stack.
           const rowBinGenBase = d3.bin<DataPoint, number>()
-            .value(d => +d[column.name])
+            .value(d => cellValueToNumber(d[column.name]))
             .domain([minDomain, maxDomain]);
           const rowBinGen = Array.isArray(thresholds)
             ? rowBinGenBase.thresholds(thresholds)
@@ -1111,8 +1112,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           return;
         }
 
-        const allValues = filteredData.map(d => +d[column.name]).filter(isFinite);
-        const selectedValues = selectedData.map(d => +d[column.name]).filter(isFinite);
+        const allValues = filteredData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
+        const selectedValues = selectedData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
 
         const binGeneratorBase = d3.bin().domain([minDomain, maxDomain]);
         const binGenerator = Array.isArray(thresholds)
@@ -1244,7 +1245,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           // Issue #40: stacked-by-color bars (horizontal); see the bottom
           // histogram block for the full rationale.
           const rowBinGenBase = d3.bin<DataPoint, number>()
-            .value(d => +d[column.name])
+            .value(d => cellValueToNumber(d[column.name]))
             .domain([minDomain, maxDomain]);
           const rowBinGen = Array.isArray(thresholds)
             ? rowBinGenBase.thresholds(thresholds)
@@ -1280,8 +1281,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           return;
         }
 
-        const allValues = filteredData.map(d => +d[column.name]).filter(isFinite);
-        const selectedValues = selectedData.map(d => +d[column.name]).filter(isFinite);
+        const allValues = filteredData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
+        const selectedValues = selectedData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
 
         const binGeneratorBase = d3.bin().domain([minDomain, maxDomain]);
         const binGenerator = Array.isArray(thresholds)

--- a/src/test/columnTypeUtils.test.ts
+++ b/src/test/columnTypeUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import Papa from 'papaparse';
+import { detectColumnTypes } from '../utils/columnTypeUtils';
+import { cellValueToNumber, isFiniteCellValue } from '../utils/cellValueUtils';
+
+describe('detectColumnTypes', () => {
+  it('detects numeric columns whose leading rows are empty (sparse PCA-style file)', () => {
+    // Mirrors the reported bug: PC columns blank for the first rows.
+    const csv = [
+      'name,PC1,PC2',
+      'a,,',
+      'b,,',
+      'c,-0.00277396,-0.0194201',
+      'd,3.97848e-05,-0.0138617',
+    ].join('\n');
+    const result = Papa.parse(csv, { header: true, dynamicTyping: true, skipEmptyLines: true });
+    const rows = result.data as Record<string, number | string | null>[];
+
+    const detected = detectColumnTypes(rows, result.meta.fields);
+    expect(detected.numericColumns).toEqual(['PC1', 'PC2']);
+    expect(detected.stringColumns).toEqual(['name']);
+    expect(detected.emptyColumns).toEqual([]);
+  });
+
+  it('classifies by evidence across all rows, not row 0', () => {
+    const rows = [
+      { label: null, sparse: null, empty: null, mixed: null },
+      { label: 'x', sparse: 42, empty: null, mixed: 1 },
+      { label: 'y', sparse: null, empty: null, mixed: 'oops' },
+    ];
+    const detected = detectColumnTypes(rows);
+    expect(detected.numericColumns).toEqual(['sparse']);
+    expect(detected.stringColumns).toEqual(['label', 'mixed']); // any real text wins
+    expect(detected.emptyColumns).toEqual(['empty']);
+  });
+
+  it('ignores __id and handles empty input', () => {
+    expect(detectColumnTypes([])).toEqual({ numericColumns: [], stringColumns: [], emptyColumns: [] });
+    const detected = detectColumnTypes([{ __id: 0, a: 1 }]);
+    expect(detected.numericColumns).toEqual(['a']);
+  });
+});
+
+describe('cellValueToNumber', () => {
+  it('yields NaN for missing/blank cells instead of 0', () => {
+    expect(cellValueToNumber(null)).toBeNaN();
+    expect(cellValueToNumber(undefined)).toBeNaN();
+    expect(cellValueToNumber('')).toBeNaN();
+    expect(cellValueToNumber('  ')).toBeNaN();
+    expect(cellValueToNumber('abc')).toBeNaN();
+  });
+
+  it('passes real numbers through, including genuine zeros', () => {
+    expect(cellValueToNumber(0)).toBe(0);
+    expect(cellValueToNumber('0')).toBe(0);
+    expect(cellValueToNumber('3.97848e-05')).toBeCloseTo(3.97848e-5);
+    expect(cellValueToNumber(-0.00277396)).toBeCloseTo(-0.00277396);
+  });
+
+  it('agrees with isFiniteCellValue', () => {
+    for (const v of [null, undefined, '', ' ', 'x', 0, '0', 1.5, '2e3']) {
+      expect(Number.isFinite(cellValueToNumber(v))).toBe(isFiniteCellValue(v));
+    }
+  });
+});

--- a/src/utils/cellValueUtils.ts
+++ b/src/utils/cellValueUtils.ts
@@ -1,0 +1,15 @@
+// PapaParse (dynamicTyping) stores empty cells as null, and `+null === 0`,
+// so a plain `isFinite(+raw)` treats missing values as real zeros. These
+// helpers are the single place that decides whether a cell holds a usable
+// number; every coercion site in the render/selection path goes through them.
+
+export function isFiniteCellValue(raw: number | string | null | undefined): boolean {
+  if (raw === null || raw === undefined) return false;
+  if (typeof raw === 'string' && raw.trim() === '') return false;
+  return Number.isFinite(+raw);
+}
+
+/** Coerce a raw cell to a number, yielding NaN for missing/blank/non-numeric. */
+export function cellValueToNumber(raw: number | string | null | undefined): number {
+  return isFiniteCellValue(raw) ? +(raw as number | string) : NaN;
+}

--- a/src/utils/columnTypeUtils.ts
+++ b/src/utils/columnTypeUtils.ts
@@ -1,0 +1,52 @@
+import { isFiniteCellValue } from './cellValueUtils';
+
+// Column type detection over ALL rows, not just the first one. Sniffing only
+// row 0 drops any column whose first cell is empty (PapaParse dynamicTyping
+// turns empty cells into null, and `typeof null` is neither 'number' nor
+// 'string'), which silently discarded sparse columns like PCA scores whose
+// leading rows are blank.
+//
+// Rules per column:
+// - any non-empty string value  -> string column (dynamicTyping already
+//   converted parseable numbers, so a surviving string means real text)
+// - otherwise, any numeric value -> numeric column
+// - only nulls/blanks throughout -> empty column (reported, not plotted)
+
+export interface ColumnTypeDetection {
+  numericColumns: string[];
+  stringColumns: string[];
+  emptyColumns: string[];
+}
+
+type RawRow = Record<string, number | string | null | undefined>;
+
+export function detectColumnTypes(rows: RawRow[], fields?: string[]): ColumnTypeDetection {
+  const numericColumns: string[] = [];
+  const stringColumns: string[] = [];
+  const emptyColumns: string[] = [];
+  if (rows.length === 0) {
+    return { numericColumns, stringColumns, emptyColumns };
+  }
+
+  const columnNames = (fields ?? Object.keys(rows[0])).filter(f => f !== '__id');
+  for (const name of columnNames) {
+    let sawNumber = false;
+    let sawString = false;
+    for (const row of rows) {
+      const value = row[name];
+      if (value === null || value === undefined) continue;
+      if (typeof value === 'string') {
+        if (value.trim() === '') continue;
+        sawString = true;
+        break; // string evidence wins immediately
+      }
+      if (typeof value === 'number') {
+        if (isFiniteCellValue(value)) sawNumber = true;
+      }
+    }
+    if (sawString) stringColumns.push(name);
+    else if (sawNumber) numericColumns.push(name);
+    else emptyColumns.push(name);
+  }
+  return { numericColumns, stringColumns, emptyColumns };
+}

--- a/src/utils/histogramStackUtils.ts
+++ b/src/utils/histogramStackUtils.ts
@@ -10,18 +10,10 @@ import { CATEGORY_PALETTE, MISSING_COLOR, MISSING_SLOT, RAINBOW_BUCKETS } from '
 // merge into one visually identical segment).
 export const RAINBOW_STACK_BINS = 12;
 
-/**
- * Null-safe finite check for a raw cell value, mirroring the guard in
- * computeRainbowSlots. PapaParse (dynamicTyping) stores empty cells as
- * null, and `+null === 0`, so a plain `isFinite(+raw)` would silently bin
- * missing cells as real zero-valued rows instead of excluding them from
- * the histogram.
- */
-export function isFiniteCellValue(raw: number | string | null | undefined): boolean {
-  if (raw === null || raw === undefined) return false;
-  if (typeof raw === 'string' && raw.trim() === '') return false;
-  return Number.isFinite(+raw);
-}
+// Moved to cellValueUtils so non-histogram code (selection grid, scales,
+// point painting) can share the null-safe guard; re-exported for existing
+// import sites.
+export { isFiniteCellValue } from './cellValueUtils';
 
 export interface StackConfig {
   /** Number of color stacks, excluding the trailing missing-value stack. */

--- a/src/utils/selectionUtils.ts
+++ b/src/utils/selectionUtils.ts
@@ -1,4 +1,5 @@
 import type { DataPoint } from '../../types';
+import { cellValueToNumber } from './cellValueUtils';
 
 export function computeSelectedStateHash(selectedIds: Set<number>): string {
     // Return a concise string that changes whenever the membership of the set changes,
@@ -30,8 +31,10 @@ export function createSpatialGrid(
         Array.from({ length: gridSize }, () => [] as DataPoint[])
     );
     data.forEach((d) => {
-        const x = +d[xCol];
-        const y = +d[yCol];
+        // cellValueToNumber: missing cells (null/blank) become NaN, not 0 —
+        // otherwise sparse rows would sit in the grid as selectable ghosts.
+        const x = cellValueToNumber(d[xCol]);
+        const y = cellValueToNumber(d[yCol]);
         if (!isFinite(x) || !isFinite(y)) return;
         const sx = xScale(x);
         const sy = yScale(y);


### PR DESCRIPTION
Reported by Dan: a CSV with PC1–PC10 columns blank in the first rows showed none of them. Root cause: column-type detection sniffed only `rawData[0]` — dynamicTyping turns empty cells into `null`, whose typeof is neither number nor string, so sparse columns fell out of both lists.

Two-part fix:
1. `detectColumnTypes()` scans all rows (text anywhere → string; else any finite number → numeric; all-blank columns reported separately). Test reproduces the exact reported file shape, including `3.97848e-05` scientific notation.
2. Null-safety across the render/selection path: `+null === 0` passes `isFinite`, so without this, sparse columns would draw phantom points at 0, pollute scale domains and histogram bins, and leave selectable ghost rows in the spatial grid. All cell coercions now go through `cellValueToNumber` (missing → NaN).

209 tests (5 new), typecheck clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved column detection so sparse CSV files are classified more accurately, including columns with blank leading rows.
  * Added shared handling for numeric cell values across charting and selection features.

* **Bug Fixes**
  * Blank or missing values are now treated as missing instead of `0` in plots and brush/grid selection.
  * Numeric calculations and histograms now use consistent value conversion, improving results for sparse and mixed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->