### PR TITLE
feat: faceted filtering by category columns

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,14 @@ import { fetchCsvFromUrl, getDataUrlFromQuery } from './src/utils/urlLoader';
 import { UrlInput } from './components/UrlInput';
 import { computePCA, projectPCA, PCA_COLUMN_NAMES } from './src/utils/pca';
 import { detectColumnTypes } from './src/utils/columnTypeUtils';
+import {
+  applyFacets,
+  buildFacetSummaries,
+  countActiveFacets,
+  setColumnFacet,
+  toggleFacetValue,
+} from './src/utils/facetUtils';
+import type { FacetSelections } from './src/utils/facetUtils';
 import { stepCellSize } from './src/utils/zoomUtils';
 import type { PCAVarianceEntry } from './components/ControlPanel';
 import { clampTableHeight, computeDragHeight, isTableVisible, capTableRows } from './src/utils/tableLayout';
@@ -53,6 +61,9 @@ const App: React.FC = () => {
   const [colorMode, setColorMode] = useState<ColorMode>('none');
   const [categoryColorColumn, setCategoryColorColumn] = useState<string | null>(null);
   const [rainbowOrderColumn, setRainbowOrderColumn] = useState<string | null>(null);
+  // Issue #41: per category column, the set of selected facet values.
+  // Absent column = no facet (all rows pass).
+  const [facetSelections, setFacetSelections] = useState<FacetSelections>(new Map());
 
   // Monotonic id for data loads. A single counter guards every async stage:
   // remote fetches (URL/sample) capture the id before awaiting and drop stale
@@ -160,6 +171,7 @@ const App: React.FC = () => {
       setColorMode(prev => (prev === 'category' ? 'none' : prev));
     }
     setRainbowOrderColumn(null);
+    setFacetSelections(new Map());
     setBrushSelection(null);
     setShowColumnGroups(false);
     setColumnGroups(new Map());
@@ -362,6 +374,40 @@ const App: React.FC = () => {
     setRenderProgress(total > 0 ? { done, total } : null);
   }, []);
 
+  // Issue #41: facets restrict the dataset before anything else sees it.
+  // facetedData feeds the matrix, the data table, and the PCA fit; the brush
+  // then selects within the faceted view. With no active facets this is the
+  // `data` array itself (same reference), so canvas caches stay warm; any
+  // facet change yields a new reference, which bumps ScatterPlotMatrix's
+  // data version and invalidates cached canvases automatically.
+  const facetedData = useMemo(
+    () => applyFacets(data, facetSelections),
+    [data, facetSelections]
+  );
+
+  const facetSummaries = useMemo(
+    () => buildFacetSummaries(data, stringColumns, facetSelections),
+    [data, stringColumns, facetSelections]
+  );
+
+  // Any facet change clears the brush: the selection was made against the
+  // previous view and selected points may no longer be visible. Clearing is
+  // the predictable option (documented in issue #41's PR).
+  const handleToggleFacetValue = useCallback((column: string, value: string) => {
+    setFacetSelections(prev => toggleFacetValue(prev, column, value));
+    setBrushSelection(null);
+  }, []);
+
+  const handleSetColumnFacet = useCallback((column: string, values: Set<string> | null) => {
+    setFacetSelections(prev => setColumnFacet(prev, column, values));
+    setBrushSelection(null);
+  }, []);
+
+  const handleClearAllFacets = useCallback(() => {
+    setFacetSelections(new Map());
+    setBrushSelection(null);
+  }, []);
+
   // Issue #38: PCA over the currently visible numeric columns. PC1..PC3 are
   // appended as derived columns; clicking again recomputes and replaces them.
   // Uses displayColumns (same set the matrix renders) so an active column
@@ -372,7 +418,10 @@ const App: React.FC = () => {
       .filter(col => col.visible && !pcNameSet.has(col.name))
       .map(col => col.name);
 
-    const result = computePCA(data, inputColumnNames);
+    // Fit on the faceted (visible) rows so the components describe what the
+    // user is looking at; project ALL rows so scores remain available for
+    // rows that reappear when facets change.
+    const result = computePCA(facetedData, inputColumnNames);
     if (!result) {
       alert('PCA needs at least 2 visible numeric columns with variation and 2 complete rows.');
       return;
@@ -396,10 +445,14 @@ const App: React.FC = () => {
       name,
       ratio: result.explainedVarianceRatios[k],
     })));
-  }, [data, displayColumns]);
+  }, [data, facetedData, displayColumns]);
 
   // Issue #39: precompute the per-row color state once per mode/column/data
   // change; the canvas paint loop only reads the resulting typed array.
+  // Deliberately computed on the FULL dataset, not facetedData: slotById is
+  // indexed by __id (which spans the full dataset), and full-data assignment
+  // keeps category colors and rainbow ranks stable while faceting — points
+  // keep their color instead of reshuffling as rows are hidden.
   const colorState = useMemo(
     () => computeColorState(data, colorMode, categoryColorColumn, rainbowOrderColumn),
     [data, colorMode, categoryColorColumn, rainbowOrderColumn]
@@ -424,16 +477,16 @@ const App: React.FC = () => {
   const { tableRows, tableCapNote } = useMemo(() => {
     if (hasActiveSelection && brushSelection?.selectedIds) {
       return {
-        tableRows: data.filter(row => brushSelection.selectedIds.has(row.__id)),
+        tableRows: facetedData.filter(row => brushSelection.selectedIds.has(row.__id)),
         tableCapNote: null as string | null,
       };
     }
     if (showDataTable) {
-      const { rows, capNote } = capTableRows(data);
+      const { rows, capNote } = capTableRows(facetedData);
       return { tableRows: rows, tableCapNote: capNote };
     }
     return { tableRows: [], tableCapNote: null as string | null };
-  }, [brushSelection, data, hasActiveSelection, showDataTable]);
+  }, [brushSelection, facetedData, hasActiveSelection, showDataTable]);
 
   const tableVisible = isTableVisible(showDataTable, hasActiveSelection) && tableRows.length > 0;
 
@@ -631,6 +684,12 @@ const App: React.FC = () => {
               rainbowOrderColumn={rainbowOrderColumn}
               onResetRainbowOrder={() => setRainbowOrderColumn(null)}
               colorState={colorState}
+              facetSummaries={facetSummaries}
+              facetSelections={facetSelections}
+              activeFacetCount={countActiveFacets(facetSelections)}
+              onToggleFacetValue={handleToggleFacetValue}
+              onSetColumnFacet={handleSetColumnFacet}
+              onClearAllFacets={handleClearAllFacets}
             />
           </aside>
           <main className="flex-1 flex flex-col bg-gray-100 overflow-hidden">
@@ -680,7 +739,7 @@ const App: React.FC = () => {
                 </button>
               </div>
               <ScatterPlotMatrix
-                data={data}
+                data={facetedData}
                 columns={displayColumns}
                 onColumnReorder={handleColumnReorder}
                 brushSelection={brushSelection}

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Column, FilterMode, ColorMode } from '../types';
 import type { ColorState } from '../src/utils/colorUtils';
+import type { FacetColumnSummary, FacetSelections } from '../src/utils/facetUtils';
 import { FileUpload } from './FileUpload';
 import { UrlInput } from './UrlInput';
 import { DownloadIcon } from './icons';
@@ -54,6 +55,12 @@ interface ControlPanelProps {
   rainbowOrderColumn: string | null;
   onResetRainbowOrder: () => void;
   colorState: ColorState | null;
+  facetSummaries: FacetColumnSummary[];
+  facetSelections: FacetSelections;
+  activeFacetCount: number;
+  onToggleFacetValue: (column: string, value: string) => void;
+  onSetColumnFacet: (column: string, values: Set<string> | null) => void;
+  onClearAllFacets: () => void;
 }
 
 export const ControlPanel: React.FC<ControlPanelProps> = ({
@@ -98,7 +105,25 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   rainbowOrderColumn,
   onResetRainbowOrder,
   colorState,
+  facetSummaries,
+  facetSelections,
+  activeFacetCount,
+  onToggleFacetValue,
+  onSetColumnFacet,
+  onClearAllFacets,
 }) => {
+  // Facet columns are collapsed by default; a column with an active facet
+  // still shows its "filtered" badge while collapsed.
+  const [expandedFacetColumns, setExpandedFacetColumns] = useState<Set<string>>(new Set());
+
+  const toggleFacetColumnExpanded = (column: string) => {
+    setExpandedFacetColumns(prev => {
+      const next = new Set(prev);
+      if (next.has(column)) next.delete(column);
+      else next.add(column);
+      return next;
+    });
+  };
 
   const handleDownloadSVG = () => {
     const svgElement = document.querySelector('#scatterplot-matrix-svg');
@@ -508,6 +533,113 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
           )}
         </div>
       </div>
+
+      {facetSummaries.length > 0 && (
+        <div data-testid="facets-section">
+          <div className="flex items-center justify-between mb-2 border-b pb-2">
+            <h2 className="text-lg font-bold text-brand-dark flex items-center">
+              Facets
+              {activeFacetCount > 0 && (
+                <span
+                  className="ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold text-white bg-brand-primary rounded-full"
+                  title={`${activeFacetCount} active facet${activeFacetCount > 1 ? 's' : ''}`}
+                  data-testid="active-facet-count"
+                >
+                  {activeFacetCount}
+                </span>
+              )}
+            </h2>
+            {activeFacetCount > 0 && (
+              <button
+                onClick={onClearAllFacets}
+                className="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+          <p className="text-xs text-gray-500 mb-2">
+            Check values to restrict the plotted rows. Columns with nothing checked show all rows.
+          </p>
+          <div className="space-y-2">
+            {facetSummaries.map(summary => {
+              const selected = facetSelections.get(summary.column);
+              const isActive = !!selected && selected.size > 0;
+              const isExpanded = expandedFacetColumns.has(summary.column);
+              return (
+                <div
+                  key={summary.column}
+                  className={`rounded-lg border ${isActive ? 'border-brand-primary bg-blue-50' : 'border-gray-200 bg-gray-50'}`}
+                >
+                  <button
+                    onClick={() => toggleFacetColumnExpanded(summary.column)}
+                    className="w-full flex items-center justify-between p-2 text-left"
+                    aria-expanded={isExpanded}
+                  >
+                    <span className="text-sm font-semibold text-gray-700 truncate" title={summary.column}>
+                      <span aria-hidden="true" className="mr-1 text-gray-400">{isExpanded ? '▾' : '▸'}</span>
+                      {summary.column}
+                    </span>
+                    {isActive && (
+                      <span className="text-xs text-brand-primary font-medium flex-shrink-0 ml-2">
+                        {selected!.size} of {summary.values.length}
+                      </span>
+                    )}
+                  </button>
+                  {isExpanded && (
+                    summary.facetable ? (
+                      <div className="px-2 pb-2">
+                        <div className="flex space-x-1 mb-1">
+                          <button
+                            onClick={() =>
+                              onSetColumnFacet(summary.column, new Set(summary.values.map(v => v.value)))
+                            }
+                            className="text-xs px-1.5 py-0.5 bg-brand-primary text-white rounded hover:bg-brand-dark"
+                          >
+                            All
+                          </button>
+                          <button
+                            onClick={() => onSetColumnFacet(summary.column, null)}
+                            className="text-xs px-1.5 py-0.5 bg-gray-400 text-white rounded hover:bg-gray-600"
+                          >
+                            None
+                          </button>
+                        </div>
+                        <div className="max-h-48 overflow-y-auto space-y-0.5">
+                          {summary.values.map(entry => (
+                            <label
+                              key={entry.value}
+                              className="flex items-center text-xs text-gray-700 cursor-pointer hover:bg-gray-100 rounded px-1 py-0.5"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={!!selected?.has(entry.value)}
+                                onChange={() => onToggleFacetValue(summary.column, entry.value)}
+                                className="h-3.5 w-3.5 rounded text-brand-primary focus:ring-brand-secondary mr-2 flex-shrink-0"
+                              />
+                              <span
+                                className={`truncate ${entry.isMissing ? 'italic text-gray-500' : ''}`}
+                                title={entry.value}
+                              >
+                                {entry.value}
+                              </span>
+                              <span className="ml-auto pl-2 text-gray-400 flex-shrink-0">({entry.count})</span>
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="px-2 pb-2 text-xs text-gray-500">
+                        Column has {summary.distinctCount} distinct values — too many to facet.
+                      </p>
+                    )
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <div>
         <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Analysis</h2>

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -666,7 +666,19 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!ref.current || data.length === 0) return;
+    if (!ref.current) return;
+    if (data.length === 0) {
+      // An empty dataset (e.g. a facet combination matching no rows) must
+      // clear the previous render rather than leave a stale plot on screen —
+      // the main path below (which normally clears and repaints) is skipped
+      // entirely, so tear down the SVG and the cached canvases here.
+      d3.select(ref.current).selectAll('*').remove();
+      canvasElementsRef.current.forEach(canvas => canvas.remove());
+      canvasElementsRef.current.clear();
+      canvasRenderKeyRef.current.clear();
+      snapshotCachesRef.current.clear();
+      return;
+    }
 
     // Helper function to get mouse position relative to SVG
     const getMousePosition = (event: d3.D3BrushEvent<unknown>) => {

--- a/src/test/facetPanel.test.tsx
+++ b/src/test/facetPanel.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+import { ControlPanel } from '../../components/ControlPanel';
+import { buildFacetSummaries, MISSING_FACET_VALUE } from '../utils/facetUtils';
+import type { FacetSelections } from '../utils/facetUtils';
+import type { DataPoint } from '../../types';
+
+const data: DataPoint[] = [
+  { __id: 0, species: 'setosa', x: 1 },
+  { __id: 1, species: 'setosa', x: 2 },
+  { __id: 2, species: 'versicolor', x: 3 },
+  { __id: 3, species: '', x: 4 },
+];
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof ControlPanel>> = {}) {
+  const facetSelections: FacetSelections =
+    overrides.facetSelections ?? new Map();
+  const props: React.ComponentProps<typeof ControlPanel> = {
+    columns: [{ name: 'x', scale: 'linear', visible: true }],
+    visibleDisplayCount: 1,
+    onColumnUpdate: vi.fn(),
+    onDataLoaded: vi.fn(),
+    onLoadFromUrl: vi.fn(),
+    isUrlLoading: false,
+    filterMode: 'highlight',
+    setFilterMode: vi.fn(),
+    showHistograms: false,
+    setShowHistograms: vi.fn(),
+    showDataTable: false,
+    setShowDataTable: vi.fn(),
+    useUniformLogBins: false,
+    setUseUniformLogBins: vi.fn(),
+    globalLogScale: false,
+    onToggleGlobalLogScale: vi.fn(),
+    showIdentityLine: false,
+    setShowIdentityLine: vi.fn(),
+    showRegressionLine: false,
+    setShowRegressionLine: vi.fn(),
+    stringColumns: ['species'],
+    columnFilter: '',
+    onColumnFilterChange: vi.fn(),
+    cellSize: 150,
+    onCellSizeChange: vi.fn(),
+    showColumnGroups: false,
+    columnGroups: new Map(),
+    onToggleColumnGroups: vi.fn(),
+    onColumnGroupUpdate: vi.fn(),
+    recentFiles: [],
+    onLoadFromHistory: vi.fn(),
+    onDeleteFromHistory: vi.fn(),
+    onAddPCA: vi.fn(),
+    pcaVariance: null,
+    colorMode: 'none',
+    setColorMode: vi.fn(),
+    categoryColorColumn: null,
+    setCategoryColorColumn: vi.fn(),
+    rainbowOrderColumn: null,
+    onResetRainbowOrder: vi.fn(),
+    colorState: null,
+    facetSummaries: buildFacetSummaries(data, ['species'], facetSelections),
+    facetSelections,
+    activeFacetCount: 0,
+    onToggleFacetValue: vi.fn(),
+    onSetColumnFacet: vi.fn(),
+    onClearAllFacets: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<ControlPanel {...props} />), props };
+}
+
+describe('ControlPanel Facets section', () => {
+  it('renders the section with a collapsed entry per category column', () => {
+    const { getByTestId, getByText, queryByText } = renderPanel();
+    expect(getByTestId('facets-section')).toBeTruthy();
+    expect(getByText('species')).toBeTruthy();
+    // Collapsed by default: value checkboxes not rendered yet
+    expect(queryByText(/setosa/)).toBeNull();
+  });
+
+  it('expanding a column shows values with counts and missing entry, and toggling fires the handler', () => {
+    const { getByText, getByTestId, props } = renderPanel();
+    fireEvent.click(getByText('species'));
+
+    const section = within(getByTestId('facets-section'));
+    expect(section.getByText('setosa')).toBeTruthy();
+    expect(section.getByText('(2)')).toBeTruthy(); // setosa count
+    expect(section.getByText(MISSING_FACET_VALUE)).toBeTruthy();
+
+    const setosaCheckbox = section.getByText('setosa').closest('label')!
+      .querySelector('input')!;
+    expect(setosaCheckbox.checked).toBe(false);
+    fireEvent.click(setosaCheckbox);
+    expect(props.onToggleFacetValue).toHaveBeenCalledWith('species', 'setosa');
+  });
+
+  it('All / None shortcuts call onSetColumnFacet with every value / null', () => {
+    const { getByText, getByTestId, props } = renderPanel();
+    fireEvent.click(getByText('species'));
+    const section = within(getByTestId('facets-section'));
+
+    fireEvent.click(section.getByText('All'));
+    expect(props.onSetColumnFacet).toHaveBeenCalledWith(
+      'species',
+      new Set(['setosa', 'versicolor', MISSING_FACET_VALUE])
+    );
+
+    fireEvent.click(section.getByText('None'));
+    expect(props.onSetColumnFacet).toHaveBeenCalledWith('species', null);
+  });
+
+  it('active facets show checked boxes, the count badge, and a working Clear all', () => {
+    const facetSelections: FacetSelections = new Map([['species', new Set(['setosa'])]]);
+    const { getByText, getByTestId, props } = renderPanel({
+      facetSelections,
+      activeFacetCount: 1,
+    });
+
+    expect(getByTestId('active-facet-count').textContent).toBe('1');
+
+    fireEvent.click(getByText('species'));
+    const section = within(getByTestId('facets-section'));
+    const setosaCheckbox = section.getByText('setosa').closest('label')!
+      .querySelector('input')!;
+    expect(setosaCheckbox.checked).toBe(true);
+
+    fireEvent.click(getByText('Clear all'));
+    expect(props.onClearAllFacets).toHaveBeenCalled();
+  });
+
+  it('columns over the distinct-value cap show a note instead of checkboxes', () => {
+    const wide: DataPoint[] = Array.from({ length: 40 }, (_, i) => ({
+      __id: i,
+      id_col: `v${i}`,
+    }));
+    const { getByText, getByTestId } = renderPanel({
+      stringColumns: ['id_col'],
+      facetSummaries: buildFacetSummaries(wide, ['id_col'], new Map()),
+    });
+
+    fireEvent.click(getByText('id_col'));
+    const section = within(getByTestId('facets-section'));
+    expect(
+      section.getByText(/40 distinct values — too many to facet/)
+    ).toBeTruthy();
+    expect(section.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('renders no Facets section when there are no category columns', () => {
+    const { queryByTestId } = renderPanel({
+      stringColumns: [],
+      facetSummaries: [],
+    });
+    expect(queryByTestId('facets-section')).toBeNull();
+  });
+});

--- a/src/test/facetUtils.test.ts
+++ b/src/test/facetUtils.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import type { DataPoint } from '../../types';
+import {
+  MISSING_FACET_VALUE,
+  MAX_FACET_VALUES,
+  applyFacets,
+  buildFacetSummaries,
+  countActiveFacets,
+  getFacetValue,
+  rowPassesFacets,
+  setColumnFacet,
+  toggleFacetValue,
+} from '../utils/facetUtils';
+import type { FacetSelections } from '../utils/facetUtils';
+
+const makeRow = (id: number, fields: Record<string, string | number | null | undefined>): DataPoint => {
+  const row: DataPoint = { __id: id };
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== null && value !== undefined) row[key] = value;
+    else if (value === null) row[key] = null as unknown as string; // PapaParse stores blank cells as null
+  }
+  return row;
+};
+
+// species x habitat grid with some missing cells
+const data: DataPoint[] = [
+  makeRow(0, { species: 'setosa', habitat: 'wet' }),
+  makeRow(1, { species: 'setosa', habitat: 'dry' }),
+  makeRow(2, { species: 'versicolor', habitat: 'wet' }),
+  makeRow(3, { species: 'versicolor', habitat: null }),
+  makeRow(4, { species: 'virginica', habitat: 'dry' }),
+  makeRow(5, { species: '', habitat: 'wet' }),
+  makeRow(6, { species: '   ', habitat: 'dry' }),
+];
+
+const facets = (entries: [string, string[]][]): FacetSelections =>
+  new Map(entries.map(([col, values]) => [col, new Set(values)]));
+
+describe('getFacetValue', () => {
+  it('returns the string form of a value', () => {
+    expect(getFacetValue(data[0], 'species')).toBe('setosa');
+  });
+
+  it('stringifies numeric cells', () => {
+    expect(getFacetValue(makeRow(0, { grade: 3 }), 'grade')).toBe('3');
+  });
+
+  it('maps undefined, null, and blank strings to the missing sentinel', () => {
+    expect(getFacetValue(makeRow(0, {}), 'species')).toBe(MISSING_FACET_VALUE);
+    expect(getFacetValue(makeRow(0, { species: null }), 'species')).toBe(MISSING_FACET_VALUE);
+    expect(getFacetValue(makeRow(0, { species: '' }), 'species')).toBe(MISSING_FACET_VALUE);
+    expect(getFacetValue(makeRow(0, { species: '  ' }), 'species')).toBe(MISSING_FACET_VALUE);
+  });
+});
+
+describe('rowPassesFacets / applyFacets semantics', () => {
+  it('no facets = identity: every row passes and the SAME array reference is returned', () => {
+    expect(applyFacets(data, new Map())).toBe(data);
+    // Defensive: an empty set for a column also means "no facet"
+    expect(applyFacets(data, facets([['species', []]]))).toBe(data);
+  });
+
+  it('an active facet returns a NEW array reference (canvas cache invalidation seam)', () => {
+    const result = applyFacets(data, facets([['species', ['setosa']]]));
+    expect(result).not.toBe(data);
+    // ScatterPlotMatrix bumps its data version on reference change; a new
+    // reference per facet change is what invalidates cached canvases.
+  });
+
+  it('OR within a column: any selected value passes', () => {
+    const result = applyFacets(data, facets([['species', ['setosa', 'virginica']]]));
+    expect(result.map(r => r.__id)).toEqual([0, 1, 4]);
+  });
+
+  it('AND across columns', () => {
+    const result = applyFacets(
+      data,
+      facets([
+        ['species', ['setosa', 'versicolor']],
+        ['habitat', ['wet']],
+      ])
+    );
+    expect(result.map(r => r.__id)).toEqual([0, 2]);
+  });
+
+  it('missing/blank cells only pass when the missing entry is selected', () => {
+    const withoutMissing = applyFacets(data, facets([['species', ['setosa']]]));
+    expect(withoutMissing.every(r => getFacetValue(r, 'species') !== MISSING_FACET_VALUE)).toBe(true);
+
+    const withMissing = applyFacets(data, facets([['species', [MISSING_FACET_VALUE]]]));
+    expect(withMissing.map(r => r.__id)).toEqual([5, 6]);
+
+    const habitatMissing = applyFacets(data, facets([['habitat', [MISSING_FACET_VALUE]]]));
+    expect(habitatMissing.map(r => r.__id)).toEqual([3]);
+  });
+
+  it('a facet matching nothing yields an empty array', () => {
+    expect(applyFacets(data, facets([['species', ['nope']]]))).toEqual([]);
+  });
+
+  it('rowPassesFacets ignores columns absent from the row only via the missing entry', () => {
+    const row = makeRow(9, {});
+    expect(rowPassesFacets(row, facets([['species', ['setosa']]]))).toBe(false);
+    expect(rowPassesFacets(row, facets([['species', [MISSING_FACET_VALUE]]]))).toBe(true);
+  });
+});
+
+describe('toggleFacetValue / setColumnFacet / countActiveFacets', () => {
+  it('toggling adds then removes a value immutably', () => {
+    const start: FacetSelections = new Map();
+    const added = toggleFacetValue(start, 'species', 'setosa');
+    expect(start.size).toBe(0); // input untouched
+    expect(added.get('species')).toEqual(new Set(['setosa']));
+
+    const removed = toggleFacetValue(added, 'species', 'setosa');
+    expect(added.get('species')).toEqual(new Set(['setosa'])); // input untouched
+    expect(removed.has('species')).toBe(false); // empty set drops the column
+  });
+
+  it('setColumnFacet replaces a column facet and clears on null/empty', () => {
+    const one = setColumnFacet(new Map(), 'species', new Set(['a', 'b']));
+    expect(one.get('species')).toEqual(new Set(['a', 'b']));
+
+    const clearedNull = setColumnFacet(one, 'species', null);
+    expect(clearedNull.has('species')).toBe(false);
+
+    const clearedEmpty = setColumnFacet(one, 'species', new Set());
+    expect(clearedEmpty.has('species')).toBe(false);
+  });
+
+  it('countActiveFacets counts columns with non-empty sets', () => {
+    expect(countActiveFacets(new Map())).toBe(0);
+    expect(countActiveFacets(facets([['a', ['x']], ['b', ['y', 'z']]]))).toBe(2);
+    expect(countActiveFacets(facets([['a', []]]))).toBe(0);
+  });
+});
+
+describe('buildFacetSummaries', () => {
+  it('extracts distinct values with counts, alphabetical with missing last', () => {
+    const [species] = buildFacetSummaries(data, ['species'], new Map());
+    expect(species.facetable).toBe(true);
+    expect(species.distinctCount).toBe(4); // setosa, versicolor, virginica, (missing)
+    expect(species.values.map(v => v.value)).toEqual([
+      'setosa', 'versicolor', 'virginica', MISSING_FACET_VALUE,
+    ]);
+    expect(species.values.map(v => v.count)).toEqual([2, 2, 1, 2]);
+    expect(species.values[3].isMissing).toBe(true);
+  });
+
+  it("counts within OTHER columns' facets, excluding the column's own facet", () => {
+    const active = facets([
+      ['habitat', ['wet']],
+      ['species', ['setosa']], // must NOT constrain its own counts
+    ]);
+    const [species, habitat] = buildFacetSummaries(data, ['species', 'habitat'], active);
+
+    // species counts restricted to habitat=wet rows (ids 0, 2, 5)
+    const speciesCounts = Object.fromEntries(species.values.map(v => [v.value, v.count]));
+    expect(speciesCounts).toEqual({
+      setosa: 1,
+      versicolor: 1,
+      virginica: 0, // still listed (exists globally) so its checkbox never vanishes
+      [MISSING_FACET_VALUE]: 1,
+    });
+
+    // habitat counts restricted to species=setosa rows (ids 0, 1)
+    const habitatCounts = Object.fromEntries(habitat.values.map(v => [v.value, v.count]));
+    expect(habitatCounts).toEqual({
+      dry: 1,
+      wet: 1,
+      [MISSING_FACET_VALUE]: 0,
+    });
+  });
+
+  it('flags columns above the distinct-value cap as not facetable', () => {
+    const wide: DataPoint[] = Array.from({ length: MAX_FACET_VALUES + 5 }, (_, i) =>
+      makeRow(i, { id_col: `v${i}`, ok_col: i % 2 === 0 ? 'even' : 'odd' })
+    );
+    const [idCol, okCol] = buildFacetSummaries(wide, ['id_col', 'ok_col'], new Map());
+
+    expect(idCol.facetable).toBe(false);
+    expect(idCol.distinctCount).toBe(MAX_FACET_VALUES + 5);
+    expect(idCol.values).toEqual([]);
+
+    expect(okCol.facetable).toBe(true);
+    expect(okCol.values.map(v => v.value)).toEqual(['even', 'odd']);
+  });
+
+  it('a column with exactly MAX_FACET_VALUES distinct values is still facetable', () => {
+    const rows: DataPoint[] = Array.from({ length: MAX_FACET_VALUES }, (_, i) =>
+      makeRow(i, { c: `v${i}` })
+    );
+    const [summary] = buildFacetSummaries(rows, ['c'], new Map());
+    expect(summary.facetable).toBe(true);
+    expect(summary.values).toHaveLength(MAX_FACET_VALUES);
+  });
+});

--- a/src/test/rafRendering.test.tsx
+++ b/src/test/rafRendering.test.tsx
@@ -149,4 +149,32 @@ describe('RAF-chunked canvas rendering', () => {
             getContextSpy.mockRestore();
         }
     });
+
+    it('clears the previous plot when the dataset becomes empty', async () => {
+        const onRenderComplete = vi.fn();
+        const props = makeProps({ onRenderComplete });
+        const { container, rerender } = render(
+            <DndProvider backend={HTML5Backend}>
+                <ScatterPlotMatrix {...props} />
+            </DndProvider>
+        );
+        await waitFor(() => expect(onRenderComplete).toHaveBeenCalled());
+
+        const svg = container.querySelector('svg')!;
+        expect(svg.childNodes.length).toBeGreaterThan(0);
+        expect(container.querySelectorAll('canvas').length).toBeGreaterThan(0);
+
+        // Facet combinations can produce zero matching rows; the stale plot
+        // (SVG cells and cached canvases) must not survive.
+        rerender(
+            <DndProvider backend={HTML5Backend}>
+                <ScatterPlotMatrix {...props} data={[]} />
+            </DndProvider>
+        );
+
+        await waitFor(() => {
+            expect(svg.childNodes.length).toBe(0);
+            expect(container.querySelectorAll('canvas').length).toBe(0);
+        });
+    });
 });

--- a/src/utils/facetUtils.ts
+++ b/src/utils/facetUtils.ts
@@ -1,0 +1,186 @@
+import type { DataPoint } from '../../types';
+
+/**
+ * Faceted filtering by category (string) columns — issue #41.
+ *
+ * Semantics:
+ * - `FacetSelections` maps a column name to the set of values the user has
+ *   checked. A column absent from the map (or with an empty set) places NO
+ *   restriction on rows — all pass. The map only ever stores non-empty sets;
+ *   helpers delete a column's entry when its set becomes empty.
+ * - Rows must pass ALL actively-faceted columns (AND across columns) and
+ *   match ANY selected value within a column (OR within a column).
+ * - Missing / blank cells (undefined, null, or whitespace-only strings) are
+ *   represented by the dedicated MISSING_FACET_VALUE entry; they only pass a
+ *   column's facet if that entry is selected. (A real cell whose text equals
+ *   the sentinel is indistinguishable from a missing cell — accepted edge
+ *   case.)
+ */
+
+/** Sentinel facet entry representing missing / blank cells. */
+export const MISSING_FACET_VALUE = '(missing)';
+
+/**
+ * Columns with more distinct values than this are not offered as facets —
+ * rendering thousands of checkboxes helps nobody.
+ */
+export const MAX_FACET_VALUES = 30;
+
+export type FacetSelections = Map<string, Set<string>>;
+
+export interface FacetValueCount {
+  /** Display/selection value; MISSING_FACET_VALUE for missing cells. */
+  value: string;
+  isMissing: boolean;
+  /** Row count within the data faceted by all OTHER columns' facets. */
+  count: number;
+}
+
+export interface FacetColumnSummary {
+  column: string;
+  /** Distinct values in the FULL dataset (incl. the missing entry, if any). */
+  distinctCount: number;
+  /** False when distinctCount exceeds MAX_FACET_VALUES. */
+  facetable: boolean;
+  /** Empty when not facetable. */
+  values: FacetValueCount[];
+}
+
+/** Facet value of a cell: its string form, or the missing sentinel. */
+export function getFacetValue(row: DataPoint, column: string): string {
+  const raw = row[column];
+  if (raw === undefined || raw === null) return MISSING_FACET_VALUE;
+  const value = String(raw);
+  return value.trim() === '' ? MISSING_FACET_VALUE : value;
+}
+
+/** True when the row passes every active facet (AND across columns). */
+export function rowPassesFacets(row: DataPoint, facets: FacetSelections): boolean {
+  for (const [column, values] of facets) {
+    if (values.size === 0) continue; // defensive: empty set = no facet
+    if (!values.has(getFacetValue(row, column))) return false;
+  }
+  return true;
+}
+
+/** Number of columns with an active (non-empty) facet. */
+export function countActiveFacets(facets: FacetSelections): number {
+  let count = 0;
+  for (const values of facets.values()) {
+    if (values.size > 0) count++;
+  }
+  return count;
+}
+
+/**
+ * Rows passing all active facets. Returns the input array itself when no
+ * facet is active — the identity is load-bearing: downstream canvas caches
+ * key off the data array reference (ScatterPlotMatrix bumps its data version
+ * whenever the reference changes), so "no facets" must not allocate a new
+ * array, and any facet change must.
+ */
+export function applyFacets(data: DataPoint[], facets: FacetSelections): DataPoint[] {
+  if (countActiveFacets(facets) === 0) return data;
+  return data.filter(row => rowPassesFacets(row, facets));
+}
+
+/**
+ * Toggle one value in one column's facet. Returns a new map (new set for the
+ * touched column); the column's entry is removed entirely when its set
+ * empties, restoring "no facet on this column".
+ */
+export function toggleFacetValue(
+  facets: FacetSelections,
+  column: string,
+  value: string
+): FacetSelections {
+  const next = new Map(facets);
+  const values = new Set(next.get(column) ?? []);
+  if (values.has(value)) {
+    values.delete(value);
+  } else {
+    values.add(value);
+  }
+  if (values.size === 0) {
+    next.delete(column);
+  } else {
+    next.set(column, values);
+  }
+  return next;
+}
+
+/**
+ * Replace one column's facet wholesale ("all" / "none" shortcuts). Passing
+ * null or an empty set clears the column's facet.
+ */
+export function setColumnFacet(
+  facets: FacetSelections,
+  column: string,
+  values: Set<string> | null
+): FacetSelections {
+  const next = new Map(facets);
+  if (!values || values.size === 0) {
+    next.delete(column);
+  } else {
+    next.set(column, new Set(values));
+  }
+  return next;
+}
+
+/** Distinct facet values of a column across the given rows, with counts. */
+function countValues(data: DataPoint[], column: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const row of data) {
+    const value = getFacetValue(row, column);
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Build the per-column facet UI model.
+ *
+ * Standard faceting counts: each column's value counts are computed within
+ * the data restricted by all OTHER columns' facets (its own facet is
+ * excluded, so unchecked values keep showing what selecting them would add).
+ * Values not present in that restricted view but selected or present in the
+ * full dataset still appear with count 0, so active checkboxes never vanish.
+ *
+ * Columns whose FULL-dataset distinct count exceeds MAX_FACET_VALUES are
+ * flagged not facetable and get no value list.
+ */
+export function buildFacetSummaries(
+  data: DataPoint[],
+  stringColumns: string[],
+  facets: FacetSelections
+): FacetColumnSummary[] {
+  return stringColumns.map(column => {
+    const globalCounts = countValues(data, column);
+    const distinctCount = globalCounts.size;
+    if (distinctCount > MAX_FACET_VALUES) {
+      return { column, distinctCount, facetable: false, values: [] };
+    }
+
+    // Counts within the view faceted by every OTHER column.
+    const otherFacets = setColumnFacet(facets, column, null);
+    const facetedCounts =
+      countActiveFacets(otherFacets) === 0
+        ? globalCounts
+        : countValues(applyFacets(data, otherFacets), column);
+
+    const values: FacetValueCount[] = [...globalCounts.keys()]
+      .map(value => ({
+        value,
+        isMissing: value === MISSING_FACET_VALUE,
+        count: facetedCounts.get(value) ?? 0,
+      }))
+      // Stable, predictable order: alphabetical, missing entry last.
+      .sort((a, b) =>
+        a.isMissing !== b.isMissing
+          ? Number(a.isMissing) - Number(b.isMissing)
+          : a.value.localeCompare(b.value)
+      );
+
+    return { column, distinctCount, facetable: true, values };
+  });
+}

--- a/src/utils/facetUtils.ts
+++ b/src/utils/facetUtils.ts
@@ -154,6 +154,13 @@ export function buildFacetSummaries(
   stringColumns: string[],
   facets: FacetSelections
 ): FacetColumnSummary[] {
+  // For a column WITHOUT its own facet, "all OTHER columns' facets" equals
+  // ALL active facets — so every such column shares one filtered view.
+  // Compute it lazily once instead of re-scanning the dataset per column.
+  let sharedOtherView: DataPoint[] | null = null;
+  const getSharedOtherView = () =>
+    (sharedOtherView ??= applyFacets(data, facets));
+
   return stringColumns.map(column => {
     const globalCounts = countValues(data, column);
     const distinctCount = globalCounts.size;
@@ -162,11 +169,15 @@ export function buildFacetSummaries(
     }
 
     // Counts within the view faceted by every OTHER column.
-    const otherFacets = setColumnFacet(facets, column, null);
+    const ownFacet = facets.get(column);
+    const hasOwnFacet = ownFacet !== undefined && ownFacet.size > 0;
+    const otherFacetCount = countActiveFacets(facets) - (hasOwnFacet ? 1 : 0);
     const facetedCounts =
-      countActiveFacets(otherFacets) === 0
+      otherFacetCount === 0
         ? globalCounts
-        : countValues(applyFacets(data, otherFacets), column);
+        : hasOwnFacet
+          ? countValues(applyFacets(data, setColumnFacet(facets, column, null)), column)
+          : countValues(getSharedOtherView(), column);
 
     const values: FacetValueCount[] = [...globalCounts.keys()]
       .map(value => ({


### PR DESCRIPTION
Closes #41

Adds faceted filtering by category (string) columns: a **Facets** section in the control panel with a collapsible entry per category column, checkbox value lists with row counts, All/None shortcuts per column, and a Clear-all button with an active-facet count badge.

## Semantics

- **State**: `facetSelections: Map<column, Set<value>>`. A column absent from the map (or with an empty set) places no restriction — all rows pass. `None` clears a column's facet; `All` explicitly checks every value (handy as a starting point for excluding values one by one).
- **Composition**: AND across columns, OR within a column's selected values.
- **Missing values**: blank/null cells map to a dedicated *(missing)* entry (shown italic, sorted last) and only pass a column's facet when that entry is selected.
- **Distinct-value cap**: columns with more than 30 distinct values get a note ("column has N distinct values — too many to facet") instead of thousands of checkboxes.
- **Counts**: standard faceting — each column's value counts are computed within the data restricted by all *other* columns' facets (a column's own facet never constrains its own counts, so unchecked values keep showing what selecting them would add). Values absent from the restricted view still render with count 0 so active checkboxes never vanish.

## Data flow and interplay with brushing

- A memoized `facetedData = applyFacets(data, facetSelections)` feeds `ScatterPlotMatrix`, the data table, and the PCA **fit** (all rows are still projected, so PC scores remain available when facets change). With no active facets, `applyFacets` returns the `data` array itself — canvas caches stay warm; any facet change yields a new array reference, which bumps ScatterPlotMatrix's internal data version and invalidates cached canvases automatically (identity semantics are unit-tested as the seam).
- **Color state is deliberately computed on the full dataset**, not `facetedData`: `slotById` is `__id`-indexed over the full dataset, and full-data assignment keeps category colors and rainbow ranks stable while faceting (points keep their color instead of reshuffling as rows are hidden).
- **Facets restrict; the brush selects within the faceted view.** Any facet change (toggle, All/None, Clear all) clears the brush selection — the selection was made against the previous view and selected points may no longer be visible; clearing is the predictable option. ESC continues to clear the brush as before.

## Tests

- `src/test/facetUtils.test.ts`: predicate AND/OR semantics, missing handling, no-facets identity (same array reference) vs. facet change (new reference), immutable toggle/set helpers, value+count extraction including cross-column counts and the 30-distinct cap.
- `src/test/facetPanel.test.tsx`: ControlPanel render tests — section presence, expand/collapse, counts and missing entry, checkbox/All/None/Clear-all handler wiring, cap note, no section without category columns.

## Verification

Gates: `npm run typecheck` clean, `npm run test:run` 232/232 green, `npm run build` OK. Also driven end-to-end in headless Chromium against the dev server with the iris sample: faceting to `setosa` repaints the matrix to 50 rows, brushing inside the faceted view selects within it ("Selected Data (40 rows)"), a subsequent facet change clears the brush, ESC clears the brush, and Clear all restores the full view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dataset faceting for string-based columns with per-value checkboxes, per-column expand/collapse, “All/None,” and “Clear all,” including an explicit missing-value option and value-cap messaging.
  * Faceting now drives the visualization, PCA fitting (based on visible rows), the scatter plot matrix, and the data table.
* **Bug Fixes**
  * Reset active facet selections when a new dataset is loaded.
  * Clear stale scatter plot output when the dataset becomes empty.
* **Tests**
  * Added unit and UI tests for facet logic, controls, and empty-state rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->