### PR TITLE
feat: per-cell correlation metrics — badges, border tint, sort-by-|r|

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -426,6 +426,10 @@ const App: React.FC = () => {
     );
     const sorted = sortColumnsByCorrelation(columns, data, correlationMetric, visibleNames);
     if (sorted === columns) return; // fewer than 2 visible columns
+    // Order unchanged (already sorted): skip the state update — setColumns
+    // would re-render the whole matrix — and don't arm a no-op "Restore
+    // order". Element identity suffices: the sort reuses the Column objects.
+    if (sorted.every((col, index) => col === columns[index])) return;
     setPreSortColumns(prev => prev ?? columns);
     setColumns(sorted);
   }, [columns, displayColumns, data, correlationMetric]);

--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,9 @@ import { DataTable } from './components/DataTable';
 import type { DataPoint, Column, ScaleType, BrushSelection, FilterMode, ColorMode } from './types';
 import { computeColorState } from './src/utils/colorUtils';
 import { GitHubIcon } from './components/icons';
-import { reorderColumns, filterColumns } from './src/utils/columnUtils';
+import { reorderColumns, filterColumns, restoreColumnOrder } from './src/utils/columnUtils';
+import { sortColumnsByCorrelation } from './src/utils/correlationUtils';
+import type { CorrelationKind } from './src/utils/correlationUtils';
 import { detectColumnGroups } from './src/utils/groupUtils';
 import { saveFile, getHistory, deleteEntry } from './src/utils/fileHistory';
 import type { FileHistoryEntry } from './src/utils/fileHistory';
@@ -38,6 +40,12 @@ const App: React.FC = () => {
   // Issue #50: per-cell reference line toggles (both default off)
   const [showIdentityLine, setShowIdentityLine] = useState<boolean>(false);
   const [showRegressionLine, setShowRegressionLine] = useState<boolean>(false);
+  // Issue #36: per-cell correlation metrics (all default off / Pearson)
+  const [showCorrelation, setShowCorrelation] = useState<boolean>(false);
+  const [tintCellBorders, setTintCellBorders] = useState<boolean>(false);
+  const [correlationMetric, setCorrelationMetric] = useState<CorrelationKind>('pearson');
+  // Column order saved before "sort columns by |r|" so it can be restored.
+  const [preSortColumns, setPreSortColumns] = useState<Column[] | null>(null);
   const [columnFilter, setColumnFilter] = useState<string>('');
   const [isRecalculating, setIsRecalculating] = useState<boolean>(false);
   const [renderProgress, setRenderProgress] = useState<{ done: number; total: number } | null>(null);
@@ -160,6 +168,7 @@ const App: React.FC = () => {
       setColorMode(prev => (prev === 'category' ? 'none' : prev));
     }
     setRainbowOrderColumn(null);
+    setPreSortColumns(null); // pre-sort order is dataset-specific
     setBrushSelection(null);
     setShowColumnGroups(false);
     setColumnGroups(new Map());
@@ -405,6 +414,29 @@ const App: React.FC = () => {
     [data, colorMode, categoryColorColumn, rainbowOrderColumn]
   );
 
+  // Issue #36: sort columns by mean absolute correlation against the other
+  // visible columns (descending). Visibility comes from displayColumns —
+  // the set actually on screen, i.e. after the column filter — while the
+  // reorder is applied to the base columns array through the same
+  // setColumns path as drag-reorder. The first sort snapshots the current
+  // order so "Restore column order" can undo it.
+  const handleSortByCorrelation = useCallback(() => {
+    const visibleNames = new Set<string>(
+      displayColumns.filter(col => col.visible).map(col => col.name)
+    );
+    const sorted = sortColumnsByCorrelation(columns, data, correlationMetric, visibleNames);
+    if (sorted === columns) return; // fewer than 2 visible columns
+    setPreSortColumns(prev => prev ?? columns);
+    setColumns(sorted);
+  }, [columns, displayColumns, data, correlationMetric]);
+
+  const handleRestoreColumnOrder = useCallback(() => {
+    if (!preSortColumns) return;
+    // Restore the ORDER only; visibility/scale edits made since survive.
+    setColumns(prev => restoreColumnOrder(prev, preSortColumns));
+    setPreSortColumns(null);
+  }, [preSortColumns]);
+
   // Rainbow mode: clicking a diagonal column label orders the gradient by
   // that column's rank; clicking the active column again reverts to file order.
   const handleColumnLabelClick = useCallback((columnName: string) => {
@@ -610,6 +642,15 @@ const App: React.FC = () => {
               setShowIdentityLine={setShowIdentityLine}
               showRegressionLine={showRegressionLine}
               setShowRegressionLine={setShowRegressionLine}
+              showCorrelation={showCorrelation}
+              setShowCorrelation={setShowCorrelation}
+              tintCellBorders={tintCellBorders}
+              setTintCellBorders={setTintCellBorders}
+              correlationMetric={correlationMetric}
+              setCorrelationMetric={setCorrelationMetric}
+              onSortByCorrelation={handleSortByCorrelation}
+              canRestoreColumnOrder={preSortColumns !== null}
+              onRestoreColumnOrder={handleRestoreColumnOrder}
               stringColumns={stringColumns}
               columnFilter={columnFilter}
               onColumnFilterChange={handleColumnFilterChange}
@@ -700,6 +741,9 @@ const App: React.FC = () => {
                 onColumnLabelClick={handleColumnLabelClick}
                 showIdentityLine={showIdentityLine}
                 showRegressionLine={showRegressionLine}
+                showCorrelation={showCorrelation}
+                correlationMetric={correlationMetric}
+                tintCellBorders={tintCellBorders}
               />
             </div>
             {tableVisible && (

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Column, FilterMode, ColorMode } from '../types';
+import type { CorrelationKind } from '../src/utils/correlationUtils';
 import type { ColorState } from '../src/utils/colorUtils';
 import { FileUpload } from './FileUpload';
 import { UrlInput } from './UrlInput';
@@ -33,6 +34,15 @@ interface ControlPanelProps {
   setShowIdentityLine: (show: boolean) => void;
   showRegressionLine: boolean;
   setShowRegressionLine: (show: boolean) => void;
+  showCorrelation: boolean;
+  setShowCorrelation: (show: boolean) => void;
+  tintCellBorders: boolean;
+  setTintCellBorders: (tint: boolean) => void;
+  correlationMetric: CorrelationKind;
+  setCorrelationMetric: (kind: CorrelationKind) => void;
+  onSortByCorrelation: () => void;
+  canRestoreColumnOrder: boolean;
+  onRestoreColumnOrder: () => void;
   stringColumns: string[];
   columnFilter: string;
   onColumnFilterChange: (filter: string) => void;
@@ -77,6 +87,15 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   setShowIdentityLine,
   showRegressionLine,
   setShowRegressionLine,
+  showCorrelation,
+  setShowCorrelation,
+  tintCellBorders,
+  setTintCellBorders,
+  correlationMetric,
+  setCorrelationMetric,
+  onSortByCorrelation,
+  canRestoreColumnOrder,
+  onRestoreColumnOrder,
   stringColumns,
   columnFilter,
   onColumnFilterChange,
@@ -387,6 +406,61 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
                   onChange={(e) => setShowRegressionLine(e.target.checked)}
                   className="h-4 w-4 rounded text-brand-primary focus:ring-brand-secondary"
                 />
+              </div>
+            </div>
+          </div>
+          <div>
+            <span className="font-semibold text-gray-700 text-sm">Correlation</span>
+            <div className="mt-1 space-y-1">
+              <div className="flex items-center justify-between">
+                <label htmlFor="showCorrelation" className="text-sm text-gray-600">Show correlation</label>
+                <input
+                  type="checkbox"
+                  id="showCorrelation"
+                  checked={showCorrelation}
+                  onChange={(e) => setShowCorrelation(e.target.checked)}
+                  className="h-4 w-4 rounded text-brand-primary focus:ring-brand-secondary"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <label htmlFor="tintCellBorders" className="text-sm text-gray-600">Tint borders by |r|</label>
+                <input
+                  type="checkbox"
+                  id="tintCellBorders"
+                  checked={tintCellBorders}
+                  onChange={(e) => setTintCellBorders(e.target.checked)}
+                  className="h-4 w-4 rounded text-brand-primary focus:ring-brand-secondary"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <label htmlFor="correlationMetric" className="text-sm text-gray-600">Metric</label>
+                <select
+                  id="correlationMetric"
+                  value={correlationMetric}
+                  onChange={(e) => setCorrelationMetric(e.target.value as CorrelationKind)}
+                  className="p-1 border rounded-md shadow-sm text-sm focus:ring-brand-secondary focus:border-brand-secondary"
+                >
+                  <option value="pearson">Pearson (r)</option>
+                  <option value="spearman">Spearman (ρ)</option>
+                </select>
+              </div>
+              <div className="flex items-center space-x-1 pt-1">
+                <button
+                  onClick={onSortByCorrelation}
+                  className="flex-1 text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
+                  title="Reorder visible columns by mean absolute correlation against the other visible columns (descending)"
+                >
+                  Sort columns by |r|
+                </button>
+                {canRestoreColumnOrder && (
+                  <button
+                    onClick={onRestoreColumnOrder}
+                    className="flex-1 text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
+                    title="Restore the column order from before the sort"
+                  >
+                    Restore order
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -547,7 +547,24 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         entry.fit = fitRegression(cellData, xColName, yColName, xLog, yLog);
       }
       if (needsSpearman && entry.spearman === undefined) {
-        entry.spearman = spearmanCorrelation(cellData, xColName, yColName, xLog, yLog);
+        // Spearman is symmetric — ρ(x,y) === ρ(y,x), and the log-axis row
+        // exclusions are the same either way — so when the transposed cell
+        // has already computed it, reuse that instead of re-running two
+        // O(n log n) rank sorts for the mirror half of the matrix.
+        const mirrorKey = [
+          yColName,
+          xColName,
+          yLog ? 'log' : 'linear',
+          xLog ? 'log' : 'linear',
+          dataStateHash,
+          filterMode,
+          filterMode === 'filter' ? selectedStateHash : '-',
+        ].join('|');
+        const mirrored = cache.get(mirrorKey)?.spearman;
+        entry.spearman =
+          mirrored !== undefined
+            ? mirrored
+            : spearmanCorrelation(cellData, xColName, yColName, xLog, yLog);
       }
       stats = entry;
     }

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -18,6 +18,12 @@ import {
 } from '../src/utils/histogramStackUtils';
 import { computeIdentityOverlap, fitRegression } from '../src/utils/referenceLineUtils';
 import type { RegressionFit } from '../src/utils/referenceLineUtils';
+import {
+  pearsonFromFit,
+  spearmanCorrelation,
+  correlationBorderAlpha,
+} from '../src/utils/correlationUtils';
+import type { CorrelationKind, CorrelationResult } from '../src/utils/correlationUtils';
 import { createZoomGestureController, isZoomWheelEvent, normalizeWheelDelta } from '../src/utils/zoomUtils';
 
 interface ScatterPlotMatrixProps {
@@ -50,6 +56,12 @@ interface ScatterPlotMatrixProps {
   showIdentityLine?: boolean;
   /** Draw a per-cell least-squares regression line (fit in transformed space). */
   showRegressionLine?: boolean;
+  /** Draw a compact per-cell correlation badge, e.g. "r=-0.82" (issue #36). */
+  showCorrelation?: boolean;
+  /** Metric behind the badge and border tint: Pearson r or Spearman ρ. */
+  correlationMetric?: CorrelationKind;
+  /** Tint each cell's border by |r| — transparent → strong for 0 → 1. */
+  tintCellBorders?: boolean;
 }
 
 // RAF-budgeted canvas rendering: paint at most this many cells per frame…
@@ -71,12 +83,28 @@ const SNAPSHOT_MAX_TOTAL_BYTES = 64 * 1024 * 1024;
 const IDENTITY_LINE_COLOR = '#9ca3af';
 const REGRESSION_LINE_COLOR = '#b91c1c';
 const REGRESSION_LINE_ALPHA = 0.7;
-// Only draw the small r² label when the cell is big enough for it not to
-// collide with the point cloud/axis ticks.
-const R2_LABEL_MIN_CELL_SIZE = 100;
-// Safety cap on the per-cell regression fit memo (keys include data hash and
+// Only draw the small badge (r / r²) when the cell is big enough for it not
+// to collide with the point cloud/axis ticks.
+const BADGE_MIN_CELL_SIZE = 100;
+// Correlation badge color when the regression overlay is off (with the
+// regression line on, the combined badge inherits its dark red).
+const CORRELATION_BADGE_COLOR = '#374151';
+// Border tint (issue #36): amber, deliberately distinct from the selection
+// blue (#1e40af), the dimmed gray, and the regression dark red, so the tint
+// never fights the selection/brush visuals. Opacity encodes |r|.
+const CORRELATION_BORDER_COLOR = '#d97706';
+// Safety cap on the per-cell pairwise-stats memo (keys include data hash and
 // filter state, so entries go stale; a simple clear keeps memory bounded).
-const REGRESSION_CACHE_MAX_ENTRIES = 512;
+const PAIR_STATS_CACHE_MAX_ENTRIES = 512;
+
+// One memo entry per column pair/config: the regression fit (issue #50) and
+// the Spearman correlation (issue #36) share the cache — Pearson r is
+// derived from the fit itself (r = sign(slope)·√r²). Fields are computed
+// lazily, `undefined` = not computed yet, `null` = computed but degenerate.
+interface PairStats {
+  fit?: RegressionFit | null;
+  spearman?: CorrelationResult | null;
+}
 
 interface CoordinateDisplay {
   visible: boolean;
@@ -224,6 +252,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   onColumnLabelClick,
   showIdentityLine = false,
   showRegressionLine = false,
+  showCorrelation = false,
+  correlationMetric = 'pearson',
+  tintCellBorders = false,
 }) => {
   const ref = useRef<SVGSVGElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -461,17 +492,18 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 
   const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds]);
 
-  // Memoized per-cell regression fits (issue #50): brush-driven repaints in
-  // highlight mode reuse the same fit instead of re-scanning all rows. Keys
-  // fold in everything the fit depends on: column pair, scale types, data
-  // identity, and — in filter mode only, where the fitted subset changes with
-  // the selection — the selection hash.
-  const regressionFitCacheRef = useRef<Map<string, RegressionFit | null>>(new Map());
+  // Memoized per-cell pairwise stats (issues #50/#36): brush-driven repaints
+  // in highlight mode reuse the same fit/correlation instead of re-scanning
+  // all rows. Keys fold in everything the stats depend on: column pair,
+  // scale types, data identity, and — in filter mode only, where the fitted
+  // subset changes with the selection — the selection hash.
+  const pairStatsCacheRef = useRef<Map<string, PairStats>>(new Map());
 
-  // Reference-line overlay pass (issue #50): drawn AFTER the point pass onto
-  // the same canvas, inside the same paint task, so the lines land in the
-  // cached ImageData snapshots too. Deliberately a separate draw step —
-  // it never touches the point-rendering code path.
+  // Reference-line + metrics overlay pass (issues #50/#36): drawn AFTER the
+  // point pass onto the same canvas, inside the same paint task, so lines,
+  // badges and border tints land in the cached ImageData snapshots too.
+  // Deliberately a separate draw step — it never touches the
+  // point-rendering code path.
   const drawReferenceLines = useCallback((
     canvas: HTMLCanvasElement,
     xScale: d3.ScaleLinear<number, number>,
@@ -482,9 +514,50 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     yLog: boolean,
     cellData: DataPoint[]
   ) => {
-    if (!showIdentityLine && !showRegressionLine) return;
+    const correlationActive = showCorrelation || tintCellBorders;
+    if (!showIdentityLine && !showRegressionLine && !correlationActive) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+
+    // Pairwise stats, memoized. The regression fit is needed for the
+    // regression line AND for a Pearson badge/tint (r = sign(slope)·√r²);
+    // Spearman is a separate rank pass, cached in the same entry.
+    const needsFit = showRegressionLine || (correlationActive && correlationMetric === 'pearson');
+    const needsSpearman = correlationActive && correlationMetric === 'spearman';
+    let stats: PairStats | null = null;
+    if (needsFit || needsSpearman) {
+      const cache = pairStatsCacheRef.current;
+      const statsKey = [
+        xColName,
+        yColName,
+        xLog ? 'log' : 'linear',
+        yLog ? 'log' : 'linear',
+        dataStateHash,
+        filterMode,
+        filterMode === 'filter' ? selectedStateHash : '-',
+      ].join('|');
+
+      let entry = cache.get(statsKey);
+      if (!entry) {
+        if (cache.size >= PAIR_STATS_CACHE_MAX_ENTRIES) cache.clear();
+        entry = {};
+        cache.set(statsKey, entry);
+      }
+      if (needsFit && entry.fit === undefined) {
+        entry.fit = fitRegression(cellData, xColName, yColName, xLog, yLog);
+      }
+      if (needsSpearman && entry.spearman === undefined) {
+        entry.spearman = spearmanCorrelation(cellData, xColName, yColName, xLog, yLog);
+      }
+      stats = entry;
+    }
+    const fit = stats?.fit ?? null;
+    // n < 2 (or zero variance) yields null → no badge, no tint.
+    const corr: CorrelationResult | null = correlationActive
+      ? correlationMetric === 'spearman'
+        ? stats?.spearman ?? null
+        : pearsonFromFit(fit)
+      : null;
 
     ctx.save();
     // Clip to the cell so out-of-range regression segments never bleed out.
@@ -523,63 +596,66 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       }
     }
 
-    if (showRegressionLine) {
-      const cache = regressionFitCacheRef.current;
-      const fitKey = [
-        xColName,
-        yColName,
-        xLog ? 'log' : 'linear',
-        yLog ? 'log' : 'linear',
-        dataStateHash,
-        filterMode,
-        filterMode === 'filter' ? selectedStateHash : '-',
-      ].join('|');
+    if (showRegressionLine && fit) {
+      // The fit lives in transformed space, where both screen axes are
+      // affine — so the line is straight in screen space for every
+      // linear/log combination. Map the transformed endpoints directly
+      // (avoiding a pow(10, w) round-trip that could overflow).
+      const xd = xScale.domain();
+      const yd = yScale.domain();
+      const xr = xScale.range();
+      const yr = yScale.range();
+      const u0 = xLog ? Math.log10(xd[0]) : xd[0];
+      const u1 = xLog ? Math.log10(xd[1]) : xd[1];
+      const t0 = yLog ? Math.log10(yd[0]) : yd[0];
+      const t1 = yLog ? Math.log10(yd[1]) : yd[1];
+      const wToScreenY = (w: number) => yr[0] + ((w - t0) / (t1 - t0)) * (yr[1] - yr[0]);
 
-      let fit = cache.get(fitKey);
-      if (fit === undefined) {
-        if (cache.size >= REGRESSION_CACHE_MAX_ENTRIES) cache.clear();
-        fit = fitRegression(cellData, xColName, yColName, xLog, yLog);
-        cache.set(fitKey, fit);
+      ctx.strokeStyle = REGRESSION_LINE_COLOR;
+      ctx.globalAlpha = REGRESSION_LINE_ALPHA;
+      ctx.beginPath();
+      ctx.moveTo(xr[0], wToScreenY(fit.slope * u0 + fit.intercept));
+      ctx.lineTo(xr[1], wToScreenY(fit.slope * u1 + fit.intercept));
+      ctx.stroke();
+    }
+
+    // Border tint by |r| (issue #36): a thin inset stroke whose opacity
+    // encodes the correlation strength — transparent at |r|=0, strong at 1.
+    if (tintCellBorders && corr) {
+      const alpha = correlationBorderAlpha(Math.abs(corr.r));
+      if (alpha > 0) {
+        ctx.globalAlpha = alpha;
+        ctx.strokeStyle = CORRELATION_BORDER_COLOR;
+        ctx.lineWidth = 2;
+        ctx.strokeRect(1, 1, size - 2, size - 2);
+        ctx.lineWidth = 1;
       }
+    }
 
-      if (fit) {
-        // The fit lives in transformed space, where both screen axes are
-        // affine — so the line is straight in screen space for every
-        // linear/log combination. Map the transformed endpoints directly
-        // (avoiding a pow(10, w) round-trip that could overflow).
-        const xd = xScale.domain();
-        const yd = yScale.domain();
-        const xr = xScale.range();
-        const yr = yScale.range();
-        const u0 = xLog ? Math.log10(xd[0]) : xd[0];
-        const u1 = xLog ? Math.log10(xd[1]) : xd[1];
-        const t0 = yLog ? Math.log10(yd[0]) : yd[0];
-        const t1 = yLog ? Math.log10(yd[1]) : yd[1];
-        const wToScreenY = (w: number) => yr[0] + ((w - t0) / (t1 - t0)) * (yr[1] - yr[0]);
-
-        ctx.strokeStyle = REGRESSION_LINE_COLOR;
-        ctx.globalAlpha = REGRESSION_LINE_ALPHA;
-        ctx.beginPath();
-        ctx.moveTo(xr[0], wToScreenY(fit.slope * u0 + fit.intercept));
-        ctx.lineTo(xr[1], wToScreenY(fit.slope * u1 + fit.intercept));
-        ctx.stroke();
-
-        // Small r² badge in the cell's top-right corner, only in cells large
-        // enough that it won't clutter the plot area.
-        if (size >= R2_LABEL_MIN_CELL_SIZE) {
-          ctx.font = '9px sans-serif';
-          ctx.fillStyle = REGRESSION_LINE_COLOR;
-          ctx.globalAlpha = 0.8;
-          ctx.textAlign = 'right';
-          ctx.textBaseline = 'top';
-          ctx.fillText(`r²=${fit.r2.toFixed(2)}`, size - padding / 2 - 2, padding / 2 + 2);
-        }
+    // Combined badge in the cell's top-right corner (one line — the r and
+    // r² labels must never overlap), only in cells large enough that it
+    // won't clutter the plot area.
+    if (size >= BADGE_MIN_CELL_SIZE) {
+      const badgeParts: string[] = [];
+      if (showCorrelation && corr) {
+        badgeParts.push(`${correlationMetric === 'spearman' ? 'ρ' : 'r'}=${corr.r.toFixed(2)}`);
+      }
+      if (showRegressionLine && fit) {
+        badgeParts.push(`r²=${fit.r2.toFixed(2)}`);
+      }
+      if (badgeParts.length > 0) {
+        ctx.font = '9px sans-serif';
+        ctx.fillStyle = showRegressionLine && fit ? REGRESSION_LINE_COLOR : CORRELATION_BADGE_COLOR;
+        ctx.globalAlpha = 0.8;
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'top';
+        ctx.fillText(badgeParts.join('  '), size - padding / 2 - 2, padding / 2 + 2);
       }
     }
 
     ctx.restore();
     ctx.globalAlpha = 1;
-  }, [showIdentityLine, showRegressionLine, size, padding, dataStateHash, filterMode, selectedStateHash]);
+  }, [showIdentityLine, showRegressionLine, showCorrelation, correlationMetric, tintCellBorders, size, padding, dataStateHash, filterMode, selectedStateHash]);
 
   // Compute stats from appropriate dataset: filtered data when in filter mode with selection, otherwise full data
   const dataForStats = useMemo(() => {
@@ -898,6 +974,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         size,
         showIdentityLine,
         showRegressionLine,
+        showCorrelation,
+        tintCellBorders,
+        correlationMetric,
         colorStateHash: colorState?.hash ?? 'none',
       });
       const previousKey = canvasRenderKeyRef.current.get(canvasKey);
@@ -1457,7 +1536,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (timeoutId !== null) clearTimeout(timeoutId);
     };
-  }, [data, columns, onBrush, filteredData, selectedData, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, drawReferenceLines, showIdentityLine, showRegressionLine, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, colorState, onRenderComplete, onRenderProgress]);
+  }, [data, columns, onBrush, filteredData, selectedData, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, drawReferenceLines, showIdentityLine, showRegressionLine, showCorrelation, tintCellBorders, correlationMetric, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, colorState, onRenderComplete, onRenderProgress]);
 
   return (
     <div

--- a/src/test/colorUtils.test.ts
+++ b/src/test/colorUtils.test.ts
@@ -168,6 +168,9 @@ describe('render cache key includes color state', () => {
     size: 150,
     showIdentityLine: false,
     showRegressionLine: false,
+    showCorrelation: false,
+    tintCellBorders: false,
+    correlationMetric: 'pearson',
   };
 
   it('changes the render key when the color mode changes', () => {

--- a/src/test/correlationMetrics.test.ts
+++ b/src/test/correlationMetrics.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+import {
+    pearsonCorrelation,
+    pearsonFromFit,
+    spearmanCorrelation,
+    rankTransform,
+    computeCorrelation,
+    correlationBorderAlpha,
+    sortColumnsByCorrelation,
+} from '../utils/correlationUtils';
+import { restoreColumnOrder } from '../utils/columnUtils';
+import { buildRenderKey } from '../utils/renderKeyUtils';
+import type { RenderKeyParts } from '../utils/renderKeyUtils';
+import type { Column, DataPoint } from '../../types';
+
+const rows = (points: Array<[number | null, number | null]>): DataPoint[] =>
+    points.map(([x, y], i) => ({ __id: i, x, y } as unknown as DataPoint));
+
+const col = (name: string, visible = true): Column => ({ name, scale: 'linear', visible });
+
+describe('pearsonCorrelation', () => {
+    it('matches the hand-computed value for a positive relationship', () => {
+        // Points (1,2),(2,3),(3,5),(4,4):
+        //   cov = 1.0, varX = varY = 1.25 → r = 1 / √(1.25·1.25) = 0.8
+        const result = pearsonCorrelation(rows([[1, 2], [2, 3], [3, 5], [4, 4]]), 'x', 'y');
+        expect(result).not.toBeNull();
+        expect(result!.r).toBeCloseTo(0.8, 10);
+        expect(result!.n).toBe(4);
+    });
+
+    it('matches the hand-computed value for a negative relationship', () => {
+        // Points (1,5),(2,4),(3,2),(4,3):
+        //   cov = -1.0, varX = varY = 1.25 → r = -0.8
+        const result = pearsonCorrelation(rows([[1, 5], [2, 4], [3, 2], [4, 3]]), 'x', 'y');
+        expect(result).not.toBeNull();
+        expect(result!.r).toBeCloseTo(-0.8, 10);
+    });
+
+    it('returns exactly ±1 for perfectly linear data', () => {
+        expect(pearsonCorrelation(rows([[1, 3], [2, 5], [3, 7]]), 'x', 'y')!.r).toBeCloseTo(1, 10);
+        expect(pearsonCorrelation(rows([[1, 9], [2, 7], [3, 5]]), 'x', 'y')!.r).toBeCloseTo(-1, 10);
+    });
+
+    it('computes in transformed space when an axis is log', () => {
+        // u = log10(x) = 1, 2, 3 against y = 5, 8, 11: perfectly linear.
+        const result = pearsonCorrelation(rows([[10, 5], [100, 8], [1000, 11]]), 'x', 'y', true, false);
+        expect(result).not.toBeNull();
+        expect(result!.r).toBeCloseTo(1, 10);
+    });
+
+    it('is undefined (null) for constant columns and n < 2', () => {
+        expect(pearsonCorrelation(rows([[4, 1], [4, 2], [4, 3]]), 'x', 'y')).toBeNull(); // constant x
+        expect(pearsonCorrelation(rows([[1, 5], [2, 5], [3, 5]]), 'x', 'y')).toBeNull(); // constant y
+        expect(pearsonCorrelation(rows([[1, 2]]), 'x', 'y')).toBeNull();
+        expect(pearsonCorrelation([], 'x', 'y')).toBeNull();
+    });
+
+    it('handles missing values pairwise-complete (null is not zero)', () => {
+        // The (null, 100) row would wreck r if null coerced to x = 0;
+        // the (5, null) row likewise. Only the 4 complete rows participate.
+        const data = rows([[1, 2], [2, 3], [null, 100], [3, 5], [4, 4], [5, null]]);
+        const result = pearsonCorrelation(data, 'x', 'y');
+        expect(result).not.toBeNull();
+        expect(result!.n).toBe(4);
+        expect(result!.r).toBeCloseTo(0.8, 10);
+    });
+});
+
+describe('pearsonFromFit', () => {
+    it('returns null for a null fit', () => {
+        expect(pearsonFromFit(null)).toBeNull();
+    });
+
+    it('returns null for the constant-y fit (slope 0, r² reported as 1)', () => {
+        expect(pearsonFromFit({ slope: 0, intercept: 5, r2: 1, n: 3 })).toBeNull();
+    });
+
+    it('recovers r = sign(slope)·√r²', () => {
+        expect(pearsonFromFit({ slope: -2, intercept: 0, r2: 0.64, n: 10 }))
+            .toEqual({ r: -0.8, n: 10 });
+        expect(pearsonFromFit({ slope: 0.5, intercept: 1, r2: 0.25, n: 7 }))
+            .toEqual({ r: 0.5, n: 7 });
+    });
+});
+
+describe('rankTransform', () => {
+    it('assigns average ranks to ties', () => {
+        expect(rankTransform([10, 20, 20, 30])).toEqual([1, 2.5, 2.5, 4]);
+    });
+
+    it('keeps input order (ranks are positional)', () => {
+        expect(rankTransform([30, 10, 20])).toEqual([3, 1, 2]);
+    });
+
+    it('handles all-tied and empty inputs', () => {
+        expect(rankTransform([5, 5, 5])).toEqual([2, 2, 2]);
+        expect(rankTransform([])).toEqual([]);
+    });
+});
+
+describe('spearmanCorrelation', () => {
+    it('is ±1 for monotone (even nonlinear) relationships', () => {
+        const up = rows([[1, Math.E], [2, Math.E ** 2], [3, Math.E ** 3], [4, Math.E ** 4]]);
+        expect(spearmanCorrelation(up, 'x', 'y')!.r).toBeCloseTo(1, 10);
+        const down = rows([[1, 1], [2, 1 / 2], [3, 1 / 3], [4, 1 / 4]]);
+        expect(spearmanCorrelation(down, 'x', 'y')!.r).toBeCloseTo(-1, 10);
+    });
+
+    it('matches Pearson-on-ranks by hand with ties', () => {
+        // x ranks [1,2,3,4]; y = [10,30,30,50] → ranks [1,2.5,2.5,4]
+        //   cov = 1.125, varX = 1.25, varY = 1.125 → ρ = √(1.125/1.25) = √0.9
+        const result = spearmanCorrelation(rows([[1, 10], [2, 30], [3, 30], [4, 50]]), 'x', 'y');
+        expect(result).not.toBeNull();
+        expect(result!.r).toBeCloseTo(Math.sqrt(0.9), 10);
+        expect(result!.n).toBe(4);
+    });
+
+    it('handles missing values pairwise-complete', () => {
+        const data = rows([[1, 1], [2, 4], [null, 999], [3, 9], [4, null], [4.5, 20]]);
+        const result = spearmanCorrelation(data, 'x', 'y');
+        expect(result).not.toBeNull();
+        expect(result!.n).toBe(4);
+        expect(result!.r).toBeCloseTo(1, 10);
+    });
+
+    it('excludes non-positive values on a log axis (matching drawable points)', () => {
+        const data = rows([[-1, 999], [0, 998], [1, 1], [10, 2], [100, 3]]);
+        const result = spearmanCorrelation(data, 'x', 'y', true, false);
+        expect(result).not.toBeNull();
+        expect(result!.n).toBe(3);
+        expect(result!.r).toBeCloseTo(1, 10);
+    });
+
+    it('is undefined (null) for all-tied columns and n < 2', () => {
+        expect(spearmanCorrelation(rows([[1, 5], [2, 5], [3, 5]]), 'x', 'y')).toBeNull();
+        expect(spearmanCorrelation(rows([[1, 2]]), 'x', 'y')).toBeNull();
+    });
+});
+
+describe('computeCorrelation (metric dispatch)', () => {
+    it('routes to the requested metric', () => {
+        // Nonlinear monotone: Pearson < 1, Spearman = 1.
+        const data = rows([[1, 1], [2, 4], [3, 9], [4, 100]]);
+        expect(computeCorrelation(data, 'x', 'y', 'spearman')!.r).toBeCloseTo(1, 10);
+        expect(computeCorrelation(data, 'x', 'y', 'pearson')!.r).toBeLessThan(1);
+    });
+});
+
+describe('correlationBorderAlpha', () => {
+    it('maps |r| 0 → transparent and 1 → strong', () => {
+        expect(correlationBorderAlpha(0)).toBe(0);
+        expect(correlationBorderAlpha(1)).toBeCloseTo(0.8, 10);
+    });
+
+    it('is monotone and clamped', () => {
+        expect(correlationBorderAlpha(0.3)).toBeLessThan(correlationBorderAlpha(0.7));
+        expect(correlationBorderAlpha(2)).toBeCloseTo(0.8, 10);
+        expect(correlationBorderAlpha(NaN)).toBe(0);
+    });
+});
+
+describe('sortColumnsByCorrelation', () => {
+    // Known matrix: b = 2a (|r| = 1); c is exactly orthogonal to both
+    // (cov(a, c) = cov(b, c) = 0). Mean |r|: a = b = 0.5, c = 0.
+    const data: DataPoint[] = [
+        { __id: 0, a: 1, b: 2, c: 1 },
+        { __id: 1, a: 2, b: 4, c: -1 },
+        { __id: 2, a: 3, b: 6, c: -1 },
+        { __id: 3, a: 4, b: 8, c: 1 },
+    ];
+
+    it('orders visible columns by mean |r| descending, stable on ties', () => {
+        const sorted = sortColumnsByCorrelation([col('c'), col('a'), col('b')], data);
+        // a and b tie at 0.5 → keep their original relative order (a first).
+        expect(sorted.map(c => c.name)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('leaves hidden columns in their original slots', () => {
+        const hidden = col('h', false);
+        const sorted = sortColumnsByCorrelation([col('c'), hidden, col('a'), col('b')], data);
+        expect(sorted.map(c => c.name)).toEqual(['a', 'h', 'b', 'c']);
+        expect(sorted[1]).toBe(hidden);
+    });
+
+    it('sorts columns with no defined correlation last', () => {
+        const dataWithNulls = data.map(d => ({ ...d, z: null } as unknown as DataPoint));
+        const sorted = sortColumnsByCorrelation([col('z'), col('a'), col('b')], dataWithNulls);
+        expect(sorted.map(c => c.name)).toEqual(['a', 'b', 'z']);
+    });
+
+    it('respects a visibleNames override (column-filter view)', () => {
+        // x duplicates a's values: if visibleNames were ignored it would sort
+        // to the front; instead it must stay in slot 1 untouched.
+        const dataWithX = data.map(d => ({ ...d, x: d.a } as DataPoint));
+        const sorted = sortColumnsByCorrelation(
+            [col('c'), col('x'), col('a'), col('b')],
+            dataWithX,
+            'pearson',
+            new Set(['c', 'a', 'b'])
+        );
+        expect(sorted.map(c => c.name)).toEqual(['a', 'x', 'b', 'c']);
+    });
+
+    it('supports Spearman as the sort metric', () => {
+        // y = a³ is monotone: Spearman |ρ| = 1 with a, Pearson < 1.
+        const cubic = data.map(d => ({ ...d, y: (d.a as number) ** 3 } as DataPoint));
+        const sorted = sortColumnsByCorrelation([col('c'), col('y'), col('a')], cubic, 'spearman');
+        expect(sorted.map(c => c.name)).toEqual(['y', 'a', 'c']);
+    });
+
+    it('returns the input unchanged with fewer than 2 visible columns', () => {
+        const columns = [col('a'), col('b', false)];
+        expect(sortColumnsByCorrelation(columns, data)).toBe(columns);
+    });
+});
+
+describe('restoreColumnOrder', () => {
+    it('restores the saved order', () => {
+        const a = col('a');
+        const b = col('b');
+        const c = col('c');
+        expect(restoreColumnOrder([c, a, b], [a, b, c])).toEqual([a, b, c]);
+    });
+
+    it('keeps the CURRENT column objects (edits after the sort survive)', () => {
+        const savedB = col('b'); // was visible when saved
+        const editedB = col('b', false); // hidden since
+        const restored = restoreColumnOrder([editedB, col('a')], [col('a'), savedB]);
+        expect(restored.map(c => c.name)).toEqual(['a', 'b']);
+        expect(restored[1]).toBe(editedB);
+        expect(restored[1].visible).toBe(false);
+    });
+
+    it('appends columns unknown to the saved order at the end, in current relative order', () => {
+        const restored = restoreColumnOrder(
+            [col('PC1'), col('c'), col('PC2'), col('a')],
+            [col('a'), col('c')]
+        );
+        expect(restored.map(c => c.name)).toEqual(['a', 'c', 'PC1', 'PC2']);
+    });
+});
+
+describe('buildRenderKey (correlation cache correctness)', () => {
+    const base: RenderKeyParts = {
+        xColName: 'a',
+        yColName: 'b',
+        xScale: 'linear',
+        yScale: 'log',
+        filterMode: 'highlight',
+        dataStateHash: 'v1-100-0-99',
+        selectedStateHash: 'none',
+        size: 150,
+        showIdentityLine: false,
+        showRegressionLine: false,
+        showCorrelation: false,
+        tintCellBorders: false,
+        correlationMetric: 'pearson',
+        colorStateHash: 'none',
+    };
+
+    it('changes when the correlation badge toggle changes', () => {
+        expect(buildRenderKey({ ...base, showCorrelation: true })).not.toBe(buildRenderKey(base));
+    });
+
+    it('changes when the border tint toggle changes', () => {
+        expect(buildRenderKey({ ...base, tintCellBorders: true })).not.toBe(buildRenderKey(base));
+    });
+
+    it('changes with the metric while a correlation feature is active', () => {
+        const on = { ...base, showCorrelation: true };
+        expect(buildRenderKey({ ...on, correlationMetric: 'spearman' })).not.toBe(buildRenderKey(on));
+        const tint = { ...base, tintCellBorders: true };
+        expect(buildRenderKey({ ...tint, correlationMetric: 'spearman' })).not.toBe(buildRenderKey(tint));
+    });
+
+    it('ignores the metric while both correlation toggles are off (no pixel effect)', () => {
+        expect(buildRenderKey({ ...base, correlationMetric: 'spearman' })).toBe(buildRenderKey(base));
+    });
+
+    it('distinguishes all four correlation toggle combinations', () => {
+        const keys = new Set(
+            [
+                [false, false],
+                [true, false],
+                [false, true],
+                [true, true],
+            ].map(([badge, tint]) =>
+                buildRenderKey({ ...base, showCorrelation: badge, tintCellBorders: tint })
+            )
+        );
+        expect(keys.size).toBe(4);
+    });
+});

--- a/src/test/referenceLineRendering.test.tsx
+++ b/src/test/referenceLineRendering.test.tsx
@@ -79,4 +79,48 @@ describe('ScatterPlotMatrix reference-line rendering', () => {
         );
         await waitFor(() => expect(getContextMock.mock.calls.length).toBeGreaterThan(callsBefore));
     });
+
+    // Issue #36: the correlation badge / border-tint overlay shares this
+    // paint pass — the full combination (badge + tint + regression line,
+    // Pearson and Spearman, across linear and log axes) must complete.
+    it.each(['pearson', 'spearman'] as const)(
+        'completes a render with correlation badge and border tint enabled (%s)',
+        async (metric) => {
+            const onRenderComplete = vi.fn();
+            render(
+                <DndProvider backend={HTML5Backend}>
+                    <ScatterPlotMatrix
+                        {...makeProps({ onRenderComplete })}
+                        showRegressionLine
+                        showCorrelation
+                        tintCellBorders
+                        correlationMetric={metric}
+                    />
+                </DndProvider>
+            );
+
+            await waitFor(() => expect(onRenderComplete).toHaveBeenCalled());
+        }
+    );
+
+    it('repaints cells when the correlation toggle flips', async () => {
+        const onRenderComplete = vi.fn();
+        const props = makeProps({ onRenderComplete });
+        const { rerender } = render(
+            <DndProvider backend={HTML5Backend}>
+                <ScatterPlotMatrix {...props} />
+            </DndProvider>
+        );
+        await waitFor(() => expect(onRenderComplete).toHaveBeenCalled());
+
+        const getContextMock = HTMLCanvasElement.prototype.getContext as unknown as ReturnType<typeof vi.fn>;
+        const callsBefore = getContextMock.mock.calls.length;
+
+        rerender(
+            <DndProvider backend={HTML5Backend}>
+                <ScatterPlotMatrix {...props} showCorrelation />
+            </DndProvider>
+        );
+        await waitFor(() => expect(getContextMock.mock.calls.length).toBeGreaterThan(callsBefore));
+    });
 });

--- a/src/test/referenceLines.test.ts
+++ b/src/test/referenceLines.test.ts
@@ -149,6 +149,9 @@ describe('buildRenderKey (reference-line cache correctness)', () => {
         size: 150,
         showIdentityLine: false,
         showRegressionLine: false,
+        showCorrelation: false,
+        tintCellBorders: false,
+        correlationMetric: 'pearson',
         colorStateHash: 'none',
     };
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -19,6 +19,8 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
   stroke: vi.fn(),
   setLineDash: vi.fn(),
   fillText: vi.fn(),
+  // Border tint by |r| (issue #36)
+  strokeRect: vi.fn(),
 })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
 HTMLCanvasElement.prototype.toDataURL = vi.fn(() => 'data:image/png;base64,mock');

--- a/src/utils/columnUtils.ts
+++ b/src/utils/columnUtils.ts
@@ -6,6 +6,26 @@ export function reorderColumns(columns: Column[], dragIndex: number, hoverIndex:
     return newColumns;
 }
 
+/**
+ * Restore a previously saved column ORDER onto the current columns (issue
+ * #36: "restore original order" after sort-by-correlation). Only the order
+ * is taken from `savedOrder`; the column objects themselves come from
+ * `current`, so visibility/scale/name edits made after the sort survive.
+ * Columns not present in the saved order (e.g. PCA columns added later)
+ * keep their relative order and go to the end.
+ */
+export function restoreColumnOrder(current: Column[], savedOrder: Column[]): Column[] {
+    const rank = new Map<string, number>();
+    savedOrder.forEach((col, index) => {
+        if (!rank.has(col.name)) rank.set(col.name, index);
+    });
+    return [...current].sort((a, b) => {
+        const ra = rank.get(a.name) ?? Number.MAX_SAFE_INTEGER;
+        const rb = rank.get(b.name) ?? Number.MAX_SAFE_INTEGER;
+        return ra === rb ? 0 : ra - rb; // stable ties (incl. both-unknown)
+    });
+}
+
 export function filterColumns(columns: Column[], filter: string): Column[] {
     const normalizedFilter = filter.trim().toLowerCase();
 

--- a/src/utils/correlationUtils.ts
+++ b/src/utils/correlationUtils.ts
@@ -1,0 +1,231 @@
+import type { Column, DataPoint } from '../../types';
+import { fitRegression } from './referenceLineUtils';
+import type { RegressionFit } from './referenceLineUtils';
+import { cellValueToNumber } from './cellValueUtils';
+
+/**
+ * Per-cell correlation metrics (issue #36).
+ *
+ * All math here is pure and canvas-free so it unit-tests without a DOM.
+ *
+ * Metric semantics:
+ * - Pearson r for a cell is derived from the least-squares fit that the
+ *   regression overlay (issue #50) already computes: r = sign(slope)·√r².
+ *   The fit lives in *transformed* space (log10 for log axes), so the badge
+ *   reports the correlation of the point cloud as actually drawn — and the
+ *   two features share one memoized computation.
+ * - Spearman ρ is Pearson on average ranks. Ranks are invariant under the
+ *   monotone log transform, but the log axes still decide which rows are
+ *   excluded (non-positive values are not drawable on a log axis), so the
+ *   flags are threaded through for consistency with the visible points.
+ * - Missing values are handled pairwise-complete: only rows finite in BOTH
+ *   columns participate (via cellValueToNumber — `+null === 0` must never
+ *   smuggle missing cells in as zeros). Fewer than 2 usable rows, or zero
+ *   variance in either column, yields null ("no defined correlation").
+ */
+
+export type CorrelationKind = 'pearson' | 'spearman';
+
+export interface CorrelationResult {
+    /** Correlation coefficient in [-1, 1]. */
+    r: number;
+    /** Number of pairwise-complete rows that participated. */
+    n: number;
+}
+
+/**
+ * Pearson r recovered from an existing regression fit:
+ * r = sign(slope)·√r². Returns null for a null fit (degenerate x) and for
+ * the constant-y case (slope 0 with r² reported as 1 by fitRegression),
+ * where the correlation is 0/0-undefined.
+ */
+export function pearsonFromFit(fit: RegressionFit | null): CorrelationResult | null {
+    if (!fit) return null;
+    // fitRegression reports a constant-y fit as slope 0, r² 1 (zero
+    // residual). Pearson is undefined there (zero variance in y).
+    if (fit.slope === 0 && fit.r2 === 1) return null;
+    return { r: Math.sign(fit.slope) * Math.sqrt(fit.r2), n: fit.n };
+}
+
+/**
+ * Pearson correlation of yCol vs xCol over the pairwise-complete rows,
+ * in transformed space when the corresponding axis is log (see module doc).
+ */
+export function pearsonCorrelation(
+    data: DataPoint[],
+    xCol: string,
+    yCol: string,
+    xLog = false,
+    yLog = false
+): CorrelationResult | null {
+    return pearsonFromFit(fitRegression(data, xCol, yCol, xLog, yLog));
+}
+
+/**
+ * Average ranks (1-based) with ties sharing their mean rank:
+ * [10, 20, 20, 30] → [1, 2.5, 2.5, 4].
+ */
+export function rankTransform(values: number[]): number[] {
+    const order = values.map((_, i) => i).sort((a, b) => values[a] - values[b]);
+    const ranks = new Array<number>(values.length);
+    let i = 0;
+    while (i < order.length) {
+        let j = i;
+        while (j + 1 < order.length && values[order[j + 1]] === values[order[i]]) j++;
+        const avgRank = (i + j) / 2 + 1;
+        for (let k = i; k <= j; k++) ranks[order[k]] = avgRank;
+        i = j + 1;
+    }
+    return ranks;
+}
+
+/** Pearson of two equal-length numeric arrays; null when undefined. */
+function pearsonOfArrays(xs: number[], ys: number[]): number | null {
+    const n = xs.length;
+    if (n < 2) return null;
+
+    let sumX = 0;
+    let sumY = 0;
+    for (let i = 0; i < n; i++) {
+        sumX += xs[i];
+        sumY += ys[i];
+    }
+    const meanX = sumX / n;
+    const meanY = sumY / n;
+
+    // Two-pass, mean-centered accumulation (same rationale as fitRegression:
+    // the one-pass form catastrophically cancels for large-offset data).
+    let varX = 0;
+    let varY = 0;
+    let cov = 0;
+    for (let i = 0; i < n; i++) {
+        const dx = xs[i] - meanX;
+        const dy = ys[i] - meanY;
+        varX += dx * dx;
+        varY += dy * dy;
+        cov += dx * dy;
+    }
+
+    // Reject zero-variance columns; thresholds mirror fitRegression's
+    // noise-floor analysis (centered sums for a constant column round to
+    // ~eps²·mean², far below 1e-24·max(1, mean²)·n).
+    if (!(varX > 1e-24 * Math.max(1, meanX * meanX) * n)) return null;
+    if (!(varY > 1e-24 * Math.max(1, meanY * meanY) * n)) return null;
+
+    const r = cov / Math.sqrt(varX * varY);
+    return Math.max(-1, Math.min(1, r));
+}
+
+/**
+ * Spearman rank correlation over the pairwise-complete rows. xLog/yLog only
+ * affect which rows participate (non-positive values are excluded on a log
+ * axis, matching the drawable point set); ranks are transform-invariant.
+ */
+export function spearmanCorrelation(
+    data: DataPoint[],
+    xCol: string,
+    yCol: string,
+    xLog = false,
+    yLog = false
+): CorrelationResult | null {
+    const xs: number[] = [];
+    const ys: number[] = [];
+    for (const d of data) {
+        const x = cellValueToNumber(d[xCol]);
+        const y = cellValueToNumber(d[yCol]);
+        if (!isFinite(x) || !isFinite(y)) continue;
+        if (xLog && x <= 0) continue;
+        if (yLog && y <= 0) continue;
+        xs.push(x);
+        ys.push(y);
+    }
+    if (xs.length < 2) return null;
+
+    const r = pearsonOfArrays(rankTransform(xs), rankTransform(ys));
+    return r === null ? null : { r, n: xs.length };
+}
+
+/** Dispatch on the metric kind (raw values; no log transforms). */
+export function computeCorrelation(
+    data: DataPoint[],
+    xCol: string,
+    yCol: string,
+    kind: CorrelationKind
+): CorrelationResult | null {
+    return kind === 'spearman'
+        ? spearmanCorrelation(data, xCol, yCol)
+        : pearsonCorrelation(data, xCol, yCol);
+}
+
+/**
+ * Border-tint opacity for a given |r|: 0 → 0 (fully transparent),
+ * 1 → 0.8 (strong), with a ^1.5 ease so weak correlations stay near
+ * invisible and never fight the selection/brush visuals.
+ */
+export function correlationBorderAlpha(absR: number): number {
+    if (!isFinite(absR)) return 0;
+    const clamped = Math.max(0, Math.min(1, absR));
+    return Math.pow(clamped, 1.5) * 0.8;
+}
+
+/**
+ * Pure column sort for "sort columns by correlation" (issue #36): visible
+ * columns are reordered by their mean absolute correlation against every
+ * other visible column, descending; hidden columns keep their slots, and
+ * ties keep their original relative order (stable sort).
+ *
+ * Correlations are computed on raw values (or ranks for Spearman) — the
+ * sort is a structural operation, independent of per-axis scale settings.
+ * Pairs with no defined correlation (fewer than 2 complete rows, zero
+ * variance) contribute nothing; a column with no defined pair at all sorts
+ * last. Returns a new array routed through the same setColumns path as
+ * drag-reorder, so reorder state stays consistent.
+ *
+ * `visibleNames` optionally overrides Column.visible — App passes the
+ * display-filtered visibility so an active column filter constrains the
+ * sort to what is actually on screen.
+ */
+export function sortColumnsByCorrelation(
+    columns: Column[],
+    data: DataPoint[],
+    kind: CorrelationKind = 'pearson',
+    visibleNames?: Set<string>
+): Column[] {
+    const isVisible = (col: Column) =>
+        visibleNames ? visibleNames.has(col.name) : col.visible;
+
+    const visibleSlots: number[] = [];
+    columns.forEach((col, index) => {
+        if (isVisible(col)) visibleSlots.push(index);
+    });
+    if (visibleSlots.length < 2) return columns;
+
+    const visible = visibleSlots.map(slot => columns[slot]);
+    const k = visible.length;
+    const sums = new Array<number>(k).fill(0);
+    const counts = new Array<number>(k).fill(0);
+    for (let i = 0; i < k; i++) {
+        for (let j = i + 1; j < k; j++) {
+            const result = computeCorrelation(data, visible[i].name, visible[j].name, kind);
+            if (result === null) continue;
+            const absR = Math.abs(result.r);
+            sums[i] += absR;
+            counts[i]++;
+            sums[j] += absR;
+            counts[j]++;
+        }
+    }
+
+    const score = (i: number) => (counts[i] > 0 ? sums[i] / counts[i] : -Infinity);
+    const order = visible.map((_, i) => i).sort((a, b) => {
+        const sa = score(a);
+        const sb = score(b);
+        return sa === sb ? 0 : sb - sa; // avoid Infinity − Infinity = NaN
+    });
+
+    const next = [...columns];
+    order.forEach((visIdx, position) => {
+        next[visibleSlots[position]] = visible[visIdx];
+    });
+    return next;
+}

--- a/src/utils/correlationUtils.ts
+++ b/src/utils/correlationUtils.ts
@@ -202,13 +202,50 @@ export function sortColumnsByCorrelation(
 
     const visible = visibleSlots.map(slot => columns[slot]);
     const k = visible.length;
+
+    // The pair loop below is O(k²): precompute each column's numeric values
+    // ONCE instead of re-parsing every row per pair. For Spearman, columns
+    // with no missing values additionally precompute their full-column ranks
+    // — the pairwise-complete subset is then the whole column for any pair
+    // of such columns, so the dominant O(n log n) rank sorts are shared
+    // across all their pairs instead of redone k² times.
+    const colValues = visible.map(col => data.map(d => cellValueToNumber(d[col.name])));
+    const colAllFinite = colValues.map(values => values.every(v => isFinite(v)));
+    const colRanks: Array<number[] | null> =
+        kind === 'spearman'
+            ? colValues.map((values, i) => (colAllFinite[i] ? rankTransform(values) : null))
+            : [];
+
+    // Same math as computeCorrelation (Pearson of values, or of ranks), just
+    // fed from the precomputed arrays; only the pairwise-complete subset is
+    // re-gathered — and re-ranked — when either column has missing cells.
+    const pairCorrelation = (i: number, j: number): number | null => {
+        const xsAll = colValues[i];
+        const ysAll = colValues[j];
+        if (colAllFinite[i] && colAllFinite[j]) {
+            return kind === 'spearman'
+                ? pearsonOfArrays(colRanks[i]!, colRanks[j]!)
+                : pearsonOfArrays(xsAll, ysAll);
+        }
+        const xs: number[] = [];
+        const ys: number[] = [];
+        for (let row = 0; row < xsAll.length; row++) {
+            if (!isFinite(xsAll[row]) || !isFinite(ysAll[row])) continue;
+            xs.push(xsAll[row]);
+            ys.push(ysAll[row]);
+        }
+        return kind === 'spearman'
+            ? pearsonOfArrays(rankTransform(xs), rankTransform(ys))
+            : pearsonOfArrays(xs, ys);
+    };
+
     const sums = new Array<number>(k).fill(0);
     const counts = new Array<number>(k).fill(0);
     for (let i = 0; i < k; i++) {
         for (let j = i + 1; j < k; j++) {
-            const result = computeCorrelation(data, visible[i].name, visible[j].name, kind);
-            if (result === null) continue;
-            const absR = Math.abs(result.r);
+            const r = pairCorrelation(i, j);
+            if (r === null) continue;
+            const absR = Math.abs(r);
             sums[i] += absR;
             counts[i]++;
             sums[j] += absR;

--- a/src/utils/referenceLineUtils.ts
+++ b/src/utils/referenceLineUtils.ts
@@ -1,4 +1,5 @@
 import type { DataPoint } from '../../types';
+import { cellValueToNumber } from './cellValueUtils';
 
 /**
  * Per-cell reference line helpers (issue #50).
@@ -67,8 +68,11 @@ export function fitRegression(
     // can silently skew the slope or spuriously reject the fit.
     const points: Array<[number, number]> = [];
     for (const d of data) {
-        const x = +d[xCol];
-        const y = +d[yCol];
+        // cellValueToNumber, not +raw: `+null === 0`, which would silently
+        // include rows with missing cells as real zeros (issue #36 requires
+        // pairwise-complete handling).
+        const x = cellValueToNumber(d[xCol]);
+        const y = cellValueToNumber(d[yCol]);
         if (!isFinite(x) || !isFinite(y)) continue;
         if (xLog && x <= 0) continue;
         if (yLog && y <= 0) continue;

--- a/src/utils/renderKeyUtils.ts
+++ b/src/utils/renderKeyUtils.ts
@@ -11,6 +11,16 @@ export interface RenderKeyParts {
   showIdentityLine: boolean;
   /** Least-squares regression line toggle. */
   showRegressionLine: boolean;
+  /** Per-cell correlation badge toggle (issue #36). */
+  showCorrelation: boolean;
+  /** Border tint by |r| toggle (issue #36). */
+  tintCellBorders: boolean;
+  /**
+   * Correlation metric ('pearson' | 'spearman'). Only folded into the key
+   * while a correlation feature is active — with both toggles off the
+   * metric cannot affect pixels, so it must not fragment the cache.
+   */
+  correlationMetric: string;
   /** From computeColorStateHash / ColorState.hash; 'none' when no coloring. */
   colorStateHash: string;
 }
@@ -33,6 +43,8 @@ const SEP = '\u0001';
  */
 export function buildRenderKey(parts: RenderKeyParts): string {
   const refLines = `ref${parts.showIdentityLine ? 1 : 0}${parts.showRegressionLine ? 1 : 0}`;
+  const corrActive = parts.showCorrelation || parts.tintCellBorders;
+  const corr = `corr${parts.showCorrelation ? 1 : 0}${parts.tintCellBorders ? 1 : 0}`;
   return [
     parts.xColName,
     parts.yColName,
@@ -43,6 +55,8 @@ export function buildRenderKey(parts: RenderKeyParts): string {
     parts.selectedStateHash,
     parts.size,
     refLines,
+    corr,
+    corrActive ? parts.correlationMetric : '-',
     parts.colorStateHash,
   ].join(SEP);
 }


### PR DESCRIPTION
Closes #36

Adds optional per-cell correlation metrics to the SPLOM, built on the #59 reference-line overlay pass and its fit memoization.

## What's included

- **Correlation badge** — a "Show correlation" toggle draws a compact per-cell badge (e.g. `r=-0.82`) in the top-right corner, same placement/size rules as the #59 r² label (hidden below 100px cells).
- **Metric select** — Pearson (r) | Spearman (ρ). Spearman made the cut because it is genuinely cheap: it is just Pearson on average ranks, so it needed only a small `rankTransform` util plus one `<select>`.
- **Border tint by |r|** — a second toggle strokes a thin amber inset border whose opacity encodes correlation strength (transparent → strong for |r| 0→1 with a ^1.5 ease). Amber was picked to stay visually clear of the selection blue, dimmed gray, and regression dark red.
- **Sort columns by |r|** — reorders visible columns by mean absolute correlation against all other visible columns (descending), attacking the many-columns wall. Implemented as pure `sortColumnsByCorrelation` routed through the existing `setColumns` path, so drag-reorder state stays consistent. "Restore order" replays the saved pre-sort order while keeping visibility/scale edits made since (`restoreColumnOrder`).

## Key decisions

- **Combined badge**: with both regression-r² and correlation badges on, they render as one line (`r=-0.82  r²=0.67`) — never overlapping.
- **Pearson shares the regression fit**: `r = sign(slope)·√r²` from the already-memoized fit, computed in the *transformed* space actually drawn (log10 on log axes) — so the badge describes the point cloud as displayed, and one capped cache (`PairStats`, 512 entries) serves both #50/#59 and #36. Spearman is cached in the same entry; ranks are log-invariant, but log axes still decide which rows participate (non-positive values are not drawable).
- **Sort metric is scale-independent**: sorting uses raw values (or ranks) — it is a structural operation, not a per-axis one. Visibility for the sort comes from `displayColumns`, so an active column filter constrains the sort to what is on screen.
- **Cache discipline**: `showCorrelation`, `tintCellBorders`, and the metric are folded into `buildRenderKey`; the metric only participates while a correlation feature is active, so flipping it with everything off cannot fragment the snapshot cache.
- **Pairwise-complete missing values**: only rows finite in BOTH columns participate; n<2 or zero variance → no badge/tint (`null`). This also surfaced (and fixes) a latent #59 bug: `fitRegression` coerced with `+raw`, and `+null === 0`, so rows with missing cells were silently fit as zeros. It now goes through `cellValueToNumber`.

## Tests (34 new + 3 rendering smoke tests; 246 total green)

- Pearson vs hand-computed values (incl. negative and log-axis cases), degenerate nulls
- `rankTransform` tie handling; Spearman vs hand-computed Pearson-on-ranks with ties
- Pairwise-complete handling with null cells (both metrics)
- Mean-|r| sort order with a known matrix, hidden-slot preservation, `visibleNames` override, Spearman sort
- `restoreColumnOrder` (order restored, later edits kept, unknown columns appended)
- Render-key inclusion of the new toggles (and metric-inactivity normalization)
- Paint-path smoke tests: badge + tint + regression across metrics; toggle flip forces repaint

`npm run typecheck` clean · `npm run test:run` 246/246 · `npm run build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added correlation overlays to the scatter plot matrix, including per-cell correlation display with Pearson/Spearman selection and optional border tinting by correlation strength.
  * Added actions to sort columns by mean absolute correlation and restore the previous column order.
* **Bug Fixes**
  * Correlation overlay changes now reliably trigger a redraw, and restoring column order behaves correctly after new dataset loads.
* **Tests**
  * Expanded test coverage for correlation metrics, sorting, rendering, and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->