### PR TITLE
feat: collapsible ControlPanel sections with View toggle group

### DIFF
--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -5,6 +5,7 @@ import type { ColorState } from '../src/utils/colorUtils';
 import type { FacetColumnSummary, FacetSelections } from '../src/utils/facetUtils';
 import { FileUpload } from './FileUpload';
 import { UrlInput } from './UrlInput';
+import { PanelSection } from './PanelSection';
 import { DownloadIcon } from './icons';
 import type { FileHistoryEntry } from '../src/utils/fileHistory';
 import { formatRelativeTime } from '../src/utils/fileHistory';
@@ -284,10 +285,21 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
     </div>
   );
 
+  // Collapsed-header status hints, cheaply derived from existing props.
+  const hiddenColumnCount = columns.filter(col => !col.visible).length;
+  const columnsHint = hiddenColumnCount > 0 ? `${hiddenColumnCount} hidden` : null;
+  const colorHint =
+    colorMode === 'none'
+      ? null
+      : colorMode === 'category'
+        ? `category${categoryColorColumn ? `: ${categoryColorColumn}` : ''}`
+        : 'rainbow';
+  const analysisHint = correlationMetric !== 'pearson' ? 'Spearman' : null;
+  const facetsHint = activeFacetCount > 0 ? `${activeFacetCount} active` : null;
+
   return (
     <div className="flex flex-col space-y-6">
-      <div>
-        <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Data Source</h2>
+      <PanelSection title="Data" defaultOpen>
         <FileUpload onDataLoaded={onDataLoaded} />
         <div className="mt-3">
           <p className="text-xs font-medium text-gray-500 mb-1">Load from URL</p>
@@ -298,41 +310,39 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
             Label column{stringColumns.length > 1 ? 's' : ''}: {stringColumns.map(c => `"${c}"`).join(', ')}
           </p>
         )}
-      </div>
-
-      {recentFiles.length > 0 && (
-        <div>
-          <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Recent Files</h2>
-          <div className="space-y-2">
-            {recentFiles.map(entry => (
-              <div
-                key={entry.id ?? `${entry.filename}-${entry.timestamp}`}
-                className="flex items-center justify-between p-2 bg-gray-50 border border-gray-200 rounded-lg"
-              >
-                <button
-                  onClick={() => onLoadFromHistory(entry)}
-                  className="flex-1 text-left min-w-0"
-                  title={`Load ${entry.filename}`}
+        {recentFiles.length > 0 && (
+          <div className="mt-4">
+            <p className="text-sm font-semibold text-gray-700 mb-2">Recent Files</p>
+            <div className="space-y-2">
+              {recentFiles.map(entry => (
+                <div
+                  key={entry.id ?? `${entry.filename}-${entry.timestamp}`}
+                  className="flex items-center justify-between p-2 bg-gray-50 border border-gray-200 rounded-lg"
                 >
-                  <div className="text-sm font-medium text-gray-800 truncate">{entry.filename}</div>
-                  <div className="text-xs text-gray-500">{formatRelativeTime(entry.timestamp)}</div>
-                </button>
-                <button
-                  onClick={() => entry.id !== undefined && onDeleteFromHistory(entry.id)}
-                  className="ml-2 text-gray-400 hover:text-red-500 flex-shrink-0"
-                  title="Remove from history"
-                  aria-label="Remove from history"
-                >
-                  <span aria-hidden="true">🗑</span>
-                </button>
-              </div>
-            ))}
+                  <button
+                    onClick={() => onLoadFromHistory(entry)}
+                    className="flex-1 text-left min-w-0"
+                    title={`Load ${entry.filename}`}
+                  >
+                    <div className="text-sm font-medium text-gray-800 truncate">{entry.filename}</div>
+                    <div className="text-xs text-gray-500">{formatRelativeTime(entry.timestamp)}</div>
+                  </button>
+                  <button
+                    onClick={() => entry.id !== undefined && onDeleteFromHistory(entry.id)}
+                    className="ml-2 text-gray-400 hover:text-red-500 flex-shrink-0"
+                    title="Remove from history"
+                    aria-label="Remove from history"
+                  >
+                    <span aria-hidden="true">🗑</span>
+                  </button>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </PanelSection>
 
-      <div>
-        <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Column Filter</h2>
+      <PanelSection title="Columns" defaultOpen hint={columnsHint}>
         <div className="space-y-3">
           <div>
             <label htmlFor="columnFilter" className="block text-sm font-medium text-gray-700 mb-1">Filter Columns</label>
@@ -350,11 +360,24 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
               </p>
             )}
           </div>
+          <div className="flex items-center justify-end">
+            <button
+              onClick={onToggleColumnGroups}
+              className={`text-xs px-2 py-1 rounded border transition-colors ${showColumnGroups
+                ? 'bg-brand-primary text-white border-brand-primary'
+                : 'bg-white text-gray-600 border-gray-300 hover:border-brand-primary hover:text-brand-primary'
+                }`}
+            >
+              {showColumnGroups ? 'Ungroup' : 'Group'}
+            </button>
+          </div>
+          <div className="space-y-1">
+            {renderColumnList()}
+          </div>
         </div>
-      </div>
+      </PanelSection>
 
-      <div>
-        <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Display Options</h2>
+      <PanelSection title="View" defaultOpen>
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <label htmlFor="filterMode" className="font-semibold text-gray-700">Selection Mode</label>
@@ -457,36 +480,6 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
                   className="h-4 w-4 rounded text-brand-primary focus:ring-brand-secondary"
                 />
               </div>
-              <div className="flex items-center justify-between">
-                <label htmlFor="correlationMetric" className="text-sm text-gray-600">Metric</label>
-                <select
-                  id="correlationMetric"
-                  value={correlationMetric}
-                  onChange={(e) => setCorrelationMetric(e.target.value as CorrelationKind)}
-                  className="p-1 border rounded-md shadow-sm text-sm focus:ring-brand-secondary focus:border-brand-secondary"
-                >
-                  <option value="pearson">Pearson (r)</option>
-                  <option value="spearman">Spearman (ρ)</option>
-                </select>
-              </div>
-              <div className="flex items-center space-x-1 pt-1">
-                <button
-                  onClick={onSortByCorrelation}
-                  className="flex-1 text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
-                  title="Reorder visible columns by mean absolute correlation against the other visible columns (descending)"
-                >
-                  Sort columns by |r|
-                </button>
-                {canRestoreColumnOrder && (
-                  <button
-                    onClick={onRestoreColumnOrder}
-                    className="flex-1 text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
-                    title="Restore the column order from before the sort"
-                  >
-                    Restore order
-                  </button>
-                )}
-              </div>
             </div>
           </div>
           <div>
@@ -505,18 +498,10 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
               className="w-full accent-brand-primary"
             />
           </div>
-          <button
-            onClick={handleDownloadSVG}
-            className="w-full mt-4 px-4 py-2 bg-brand-secondary text-white font-semibold rounded-lg shadow-md hover:bg-brand-primary transition-colors flex items-center justify-center space-x-2"
-          >
-            <DownloadIcon className="h-5 w-5" />
-            <span>Download SVG</span>
-          </button>
         </div>
-      </div>
+      </PanelSection>
 
-      <div>
-        <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Color</h2>
+      <PanelSection title="Color" defaultOpen={colorMode !== 'none'} hint={colorHint}>
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <label htmlFor="colorMode" className="font-semibold text-gray-700">Color By</label>
@@ -606,35 +591,39 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
             </div>
           )}
         </div>
-      </div>
+      </PanelSection>
 
       {facetSummaries.length > 0 && (
-        <div data-testid="facets-section">
-          <div className="flex items-center justify-between mb-2 border-b pb-2">
-            <h2 className="text-lg font-bold text-brand-dark flex items-center">
-              Facets
-              {activeFacetCount > 0 && (
-                <span
-                  className="ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold text-white bg-brand-primary rounded-full"
-                  title={`${activeFacetCount} active facet${activeFacetCount > 1 ? 's' : ''}`}
-                  data-testid="active-facet-count"
-                >
-                  {activeFacetCount}
-                </span>
-              )}
-            </h2>
+        <PanelSection
+          title="Facets"
+          defaultOpen={activeFacetCount > 0}
+          hint={facetsHint}
+          testId="facets-section"
+          badge={
+            activeFacetCount > 0 ? (
+              <span
+                className="ml-2 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-semibold text-white bg-brand-primary rounded-full"
+                title={`${activeFacetCount} active facet${activeFacetCount > 1 ? 's' : ''}`}
+                data-testid="active-facet-count"
+              >
+                {activeFacetCount}
+              </span>
+            ) : null
+          }
+        >
+          <div className="flex items-start justify-between mb-2">
+            <p className="text-xs text-gray-500 pr-2">
+              Check values to restrict the plotted rows. Columns with nothing checked show all rows.
+            </p>
             {activeFacetCount > 0 && (
               <button
                 onClick={onClearAllFacets}
-                className="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
+                className="text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors flex-shrink-0"
               >
                 Clear all
               </button>
             )}
           </div>
-          <p className="text-xs text-gray-500 mb-2">
-            Check values to restrict the plotted rows. Columns with nothing checked show all rows.
-          </p>
           <div className="space-y-2">
             {facetSummaries.map(summary => {
               const selected = facetSelections.get(summary.column);
@@ -712,43 +701,73 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
               );
             })}
           </div>
-        </div>
+        </PanelSection>
       )}
 
-      <div>
-        <h2 className="text-lg font-bold text-brand-dark mb-3 border-b pb-2">Analysis</h2>
-        <button
-          onClick={onAddPCA}
-          className="w-full px-4 py-2 bg-brand-secondary text-white font-semibold rounded-lg shadow-md hover:bg-brand-primary transition-colors"
-          title="Compute PCA over the visible numeric columns and add PC1-PC3 as derived columns"
-        >
-          Add PCA Columns
-        </button>
-        {pcaVariance && pcaVariance.length > 0 && (
-          <p className="text-xs text-gray-500 mt-2">
-            Explained variance:{' '}
-            {pcaVariance.map(pc => `${pc.name} ${(pc.ratio * 100).toFixed(1)}%`).join(', ')}
-          </p>
-        )}
-      </div>
+      <PanelSection title="Analysis" hint={analysisHint}>
+        <div className="space-y-3">
+          <div>
+            <button
+              onClick={onAddPCA}
+              className="w-full px-4 py-2 bg-brand-secondary text-white font-semibold rounded-lg shadow-md hover:bg-brand-primary transition-colors"
+              title="Compute PCA over the visible numeric columns and add PC1-PC3 as derived columns"
+            >
+              Add PCA Columns
+            </button>
+            {pcaVariance && pcaVariance.length > 0 && (
+              <p className="text-xs text-gray-500 mt-2">
+                Explained variance:{' '}
+                {pcaVariance.map(pc => `${pc.name} ${(pc.ratio * 100).toFixed(1)}%`).join(', ')}
+              </p>
+            )}
+          </div>
+          <div>
+            <span className="font-semibold text-gray-700 text-sm">Correlation</span>
+            <div className="mt-1 space-y-1">
+              <div className="flex items-center justify-between">
+                <label htmlFor="correlationMetric" className="text-sm text-gray-600">Metric</label>
+                <select
+                  id="correlationMetric"
+                  value={correlationMetric}
+                  onChange={(e) => setCorrelationMetric(e.target.value as CorrelationKind)}
+                  className="p-1 border rounded-md shadow-sm text-sm focus:ring-brand-secondary focus:border-brand-secondary"
+                >
+                  <option value="pearson">Pearson (r)</option>
+                  <option value="spearman">Spearman (ρ)</option>
+                </select>
+              </div>
+              <div className="flex items-center space-x-1 pt-1">
+                <button
+                  onClick={onSortByCorrelation}
+                  className="flex-1 text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
+                  title="Reorder visible columns by mean absolute correlation against the other visible columns (descending)"
+                >
+                  Sort columns by |r|
+                </button>
+                {canRestoreColumnOrder && (
+                  <button
+                    onClick={onRestoreColumnOrder}
+                    className="flex-1 text-xs px-2 py-1 rounded border border-gray-300 text-gray-600 hover:border-brand-primary hover:text-brand-primary transition-colors"
+                    title="Restore the column order from before the sort"
+                  >
+                    Restore order
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </PanelSection>
 
-      <div>
-        <div className="flex items-center justify-between mb-2 border-b pb-2">
-          <h2 className="text-lg font-bold text-brand-dark">Columns</h2>
-          <button
-            onClick={onToggleColumnGroups}
-            className={`text-xs px-2 py-1 rounded border transition-colors ${showColumnGroups
-              ? 'bg-brand-primary text-white border-brand-primary'
-              : 'bg-white text-gray-600 border-gray-300 hover:border-brand-primary hover:text-brand-primary'
-              }`}
-          >
-            {showColumnGroups ? 'Ungroup' : 'Group'}
-          </button>
-        </div>
-        <div className="space-y-1">
-          {renderColumnList()}
-        </div>
-      </div>
+      <PanelSection title="Export">
+        <button
+          onClick={handleDownloadSVG}
+          className="w-full px-4 py-2 bg-brand-secondary text-white font-semibold rounded-lg shadow-md hover:bg-brand-primary transition-colors flex items-center justify-center space-x-2"
+        >
+          <DownloadIcon className="h-5 w-5" />
+          <span>Download SVG</span>
+        </button>
+      </PanelSection>
     </div>
   );
 };

--- a/components/PanelSection.tsx
+++ b/components/PanelSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 
 interface PanelSectionProps {
   title: string;
@@ -26,13 +26,21 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
   children,
 }) => {
   const [open, setOpen] = useState(defaultOpen);
+  // Stable ids so assistive tech can associate the header button with the
+  // content region (aria-controls) and name the section landmark
+  // (aria-labelledby). useId avoids collisions between same-titled sections.
+  const id = useId();
+  const headerId = `${id}-header`;
+  const contentId = `${id}-content`;
 
   return (
-    <section data-testid={testId}>
+    <section data-testid={testId} aria-labelledby={headerId}>
       <button
         type="button"
+        id={headerId}
         onClick={() => setOpen(o => !o)}
         aria-expanded={open}
+        aria-controls={contentId}
         className="w-full flex items-center justify-between text-left border-b pb-2 mb-3 focus:outline-none focus:ring-2 focus:ring-brand-secondary rounded-sm"
       >
         <span className="text-lg font-bold text-brand-dark flex items-center min-w-0">
@@ -48,7 +56,9 @@ export const PanelSection: React.FC<PanelSectionProps> = ({
           </span>
         )}
       </button>
-      {open && children}
+      {/* The region element stays mounted so aria-controls always resolves;
+          children themselves are still unmounted while collapsed. */}
+      <div id={contentId}>{open && children}</div>
     </section>
   );
 };

--- a/components/PanelSection.tsx
+++ b/components/PanelSection.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+interface PanelSectionProps {
+  title: string;
+  /** Whether the section starts expanded. Open/closed state is local. */
+  defaultOpen?: boolean;
+  /** Short status hint shown on the header only while collapsed (e.g. "3 hidden"). */
+  hint?: string | null;
+  /** Always-visible header adornment (e.g. an active-count badge). */
+  badge?: React.ReactNode;
+  testId?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A collapsible control-panel section with a keyboard-accessible header
+ * button. Children are unmounted while collapsed; any state that must
+ * survive collapse should live in the parent (as ControlPanel's does).
+ */
+export const PanelSection: React.FC<PanelSectionProps> = ({
+  title,
+  defaultOpen = false,
+  hint,
+  badge,
+  testId,
+  children,
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <section data-testid={testId}>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between text-left border-b pb-2 mb-3 focus:outline-none focus:ring-2 focus:ring-brand-secondary rounded-sm"
+      >
+        <span className="text-lg font-bold text-brand-dark flex items-center min-w-0">
+          <span aria-hidden="true" className="mr-2 text-sm text-gray-400 flex-shrink-0">
+            {open ? '▾' : '▸'}
+          </span>
+          <span className="truncate">{title}</span>
+          {badge}
+        </span>
+        {!open && hint && (
+          <span className="text-xs text-gray-500 truncate max-w-[10rem] ml-2 flex-shrink-0">
+            {hint}
+          </span>
+        )}
+      </button>
+      {open && children}
+    </section>
+  );
+};

--- a/src/test/facetPanel.test.tsx
+++ b/src/test/facetPanel.test.tsx
@@ -69,17 +69,27 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof ControlPanel
   return { ...render(<ControlPanel {...props} />), props };
 }
 
+// The Facets panel section starts collapsed unless a facet is active (#58),
+// so tests exercising an inactive panel expand the section header first.
+function expandFacetsSection(utils: ReturnType<typeof render>) {
+  fireEvent.click(utils.getByRole('button', { name: /^Facets/ }));
+}
+
 describe('ControlPanel Facets section', () => {
   it('renders the section with a collapsed entry per category column', () => {
-    const { getByTestId, getByText, queryByText } = renderPanel();
+    const utils = renderPanel();
+    const { getByTestId, getByText, queryByText } = utils;
     expect(getByTestId('facets-section')).toBeTruthy();
+    expandFacetsSection(utils);
     expect(getByText('species')).toBeTruthy();
     // Collapsed by default: value checkboxes not rendered yet
     expect(queryByText(/setosa/)).toBeNull();
   });
 
   it('expanding a column shows values with counts and missing entry, and toggling fires the handler', () => {
-    const { getByText, getByTestId, props } = renderPanel();
+    const utils = renderPanel();
+    const { getByText, getByTestId, props } = utils;
+    expandFacetsSection(utils);
     fireEvent.click(getByText('species'));
 
     const section = within(getByTestId('facets-section'));
@@ -95,7 +105,9 @@ describe('ControlPanel Facets section', () => {
   });
 
   it('All / None shortcuts call onSetColumnFacet with every value / null', () => {
-    const { getByText, getByTestId, props } = renderPanel();
+    const utils = renderPanel();
+    const { getByText, getByTestId, props } = utils;
+    expandFacetsSection(utils);
     fireEvent.click(getByText('species'));
     const section = within(getByTestId('facets-section'));
 
@@ -133,11 +145,13 @@ describe('ControlPanel Facets section', () => {
       __id: i,
       id_col: `v${i}`,
     }));
-    const { getByText, getByTestId } = renderPanel({
+    const utils = renderPanel({
       stringColumns: ['id_col'],
       facetSummaries: buildFacetSummaries(wide, ['id_col'], new Map()),
     });
+    const { getByText, getByTestId } = utils;
 
+    expandFacetsSection(utils);
     fireEvent.click(getByText('id_col'));
     const section = within(getByTestId('facets-section'));
     expect(

--- a/src/test/panelSection.test.tsx
+++ b/src/test/panelSection.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { PanelSection } from '../../components/PanelSection';
 
@@ -36,7 +37,8 @@ describe('PanelSection', () => {
     expect(queryByText('export tools')).not.toBeNull();
   });
 
-  it('is keyboard-accessible: the header is a real button that toggles via keyboard activation', () => {
+  it('is keyboard-accessible: the header button toggles on Enter and Space and controls the content region', async () => {
+    const user = userEvent.setup();
     const { getByRole, queryByText } = render(
       <PanelSection title="Analysis">
         <p>analysis tools</p>
@@ -45,9 +47,20 @@ describe('PanelSection', () => {
 
     const header = getByRole('button', { name: /Analysis/ });
     expect(header.tagName).toBe('BUTTON');
-    // jsdom fires click for keyboard activation of native buttons; simulate it.
-    fireEvent.click(header);
+
+    // The button must be programmatically linked to the region it expands.
+    const contentId = header.getAttribute('aria-controls');
+    expect(contentId).toBeTruthy();
+
+    header.focus();
+    await user.keyboard('{Enter}');
+    expect(header.getAttribute('aria-expanded')).toBe('true');
     expect(queryByText('analysis tools')).not.toBeNull();
+    expect(document.getElementById(contentId!)?.textContent).toContain('analysis tools');
+
+    await user.keyboard(' ');
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(queryByText('analysis tools')).toBeNull();
   });
 
   it('shows the hint only while collapsed and the badge always', () => {

--- a/src/test/panelSection.test.tsx
+++ b/src/test/panelSection.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PanelSection } from '../../components/PanelSection';
+
+describe('PanelSection', () => {
+  it('renders children when defaultOpen and hides them after toggling closed', () => {
+    const { getByRole, queryByText } = render(
+      <PanelSection title="Data" defaultOpen>
+        <p>section content</p>
+      </PanelSection>
+    );
+
+    const header = getByRole('button', { name: /Data/ });
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(queryByText('section content')).not.toBeNull();
+
+    fireEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(queryByText('section content')).toBeNull();
+  });
+
+  it('starts collapsed by default and expands on header click', () => {
+    const { getByRole, queryByText } = render(
+      <PanelSection title="Export">
+        <p>export tools</p>
+      </PanelSection>
+    );
+
+    const header = getByRole('button', { name: /Export/ });
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+    expect(queryByText('export tools')).toBeNull();
+
+    fireEvent.click(header);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(queryByText('export tools')).not.toBeNull();
+  });
+
+  it('is keyboard-accessible: the header is a real button that toggles via keyboard activation', () => {
+    const { getByRole, queryByText } = render(
+      <PanelSection title="Analysis">
+        <p>analysis tools</p>
+      </PanelSection>
+    );
+
+    const header = getByRole('button', { name: /Analysis/ });
+    expect(header.tagName).toBe('BUTTON');
+    // jsdom fires click for keyboard activation of native buttons; simulate it.
+    fireEvent.click(header);
+    expect(queryByText('analysis tools')).not.toBeNull();
+  });
+
+  it('shows the hint only while collapsed and the badge always', () => {
+    const { getByRole, queryByText, getByTestId } = render(
+      <PanelSection
+        title="Color"
+        hint="rainbow"
+        badge={<span data-testid="color-badge">2</span>}
+      >
+        <p>color controls</p>
+      </PanelSection>
+    );
+
+    expect(queryByText('rainbow')).not.toBeNull();
+    expect(getByTestId('color-badge')).toBeTruthy();
+
+    fireEvent.click(getByRole('button', { name: /Color/ }));
+    expect(queryByText('rainbow')).toBeNull();
+    expect(getByTestId('color-badge')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #58

## What

Reorganizes the (now very crowded) control panel into collapsible sections via a small reusable `PanelSection` component, and consolidates the display toggles into a single **View** group.

### PanelSection

`components/PanelSection.tsx` — keyboard-accessible native `<button>` header with chevron and `aria-expanded`; children are unmounted while collapsed (all panel state lives in `ControlPanel`/`App`, so nothing is lost). Supports an always-visible header `badge` and a `hint` string shown only while collapsed.

### Grouping chosen

| Section | Default | Contents |
|---|---|---|
| **Data** | open | FileUpload, URL input, label-column note, Recent Files (merged in as a subsection) |
| **Columns** | open | filter box, Group/Ungroup toggle, column list (visibility + per-column log scale) |
| **View** | open | Selection Mode, Show Histograms, Uniform Log Bins, Log Scale All Axes, Show Data Table, reference lines (x=y, regression), correlation badges + border tint, plot-size slider |
| **Color** | open only if a color mode is active | existing Color controls; hint e.g. "rainbow" / "category: species" when collapsed |
| **Facets** | open only if facets active | existing Facets UI; the active-count badge stays on the header while collapsed; hint "N active" |
| **Analysis** | collapsed | PCA button + explained variance, correlation metric select, sort by \|r\| / restore order |
| **Export** | collapsed | Download SVG |

Collapsed headers show cheap status hints derived from existing props ("3 hidden" on Columns, "Spearman" on Analysis, etc.).

### Deviations from the issue sketch

- **Sample data** is loaded from App's empty-state view (and on mount), not from ControlPanel, so there was nothing to move into the Data section without changing the App↔panel prop contract (which this refactor deliberately avoids).
- **Scale toggles** (Log Scale All Axes, Uniform Log Bins) and **Selection Mode** had no named home in the issue; they live in **View** alongside the other display toggles rather than a separate Scales section.
- The old "Correlation" block was split: display toggles (show badges, tint borders) went to **View**; metric select and sort-by-\|r\| went to **Analysis**.
- Facets' "Clear all" moved from the section header into the section body (the header is now a toggle button; buttons can't nest).

### Behavior preserved

Purely presentational — existing JSX moved verbatim; zero App.tsx changes. Drag-reorder (which lives on the matrix labels, not the panel), rainbow label-click ordering hint, disabled states (Uniform Log Bins without histograms, Category without string columns), and all notices are unchanged. Verified in the running app (headless Chromium screenshot of the preview build).

### Tests

- New `src/test/panelSection.test.tsx` (4 tests: toggle open/closed, aria-expanded, children unmounted when collapsed, hint-only-when-collapsed + persistent badge).
- `src/test/facetPanel.test.tsx`: tests exercising an *inactive* facet panel now expand the Facets section first (it's collapsed by default per this issue); assertions unchanged. The active-facet test needed no changes (section starts open when facets are active).

`npm run typecheck` clean · `npm run test:run` 281/281 · `npm run build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible control sections for the panel, including hints, badges, and keyboard-accessible headers.
  * Reorganized the interface into clearer sections for Data, Columns, View, Color, Facets, Analysis, and Export.
  * Moved correlation controls into the Analysis section and SVG export into its own Export section.

* **Bug Fixes**
  * Updated facet interactions so facet options are accessed after expanding the Facets section by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->