### PR TITLE
fix: PNG export replaces SVG export (points were missing)

### DIFF
--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -7,6 +7,7 @@ import { FileUpload } from './FileUpload';
 import { UrlInput } from './UrlInput';
 import { PanelSection } from './PanelSection';
 import { DownloadIcon } from './icons';
+import { renderMatrixToPngBlob, downloadBlob } from '../src/utils/exportPng';
 import type { FileHistoryEntry } from '../src/utils/fileHistory';
 import { formatRelativeTime } from '../src/utils/fileHistory';
 
@@ -145,25 +146,21 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
     });
   };
 
-  const handleDownloadSVG = () => {
-    const svgElement = document.querySelector('#scatterplot-matrix-svg');
-    if (!svgElement) {
-      alert('Could not find the SVG element to download.');
+  const handleDownloadPNG = async () => {
+    // The points live on Canvas layers, not in the SVG, so a plain SVG
+    // serialization exports an empty plot — composite both into a PNG.
+    const svgElement = document.querySelector<SVGSVGElement>('#scatterplot-matrix-svg');
+    const canvasContainer = document.querySelector<HTMLElement>('#scatterplot-matrix-canvases');
+    if (!svgElement || !canvasContainer) {
+      alert('Could not find the plot to export — load some data first.');
       return;
     }
-
-    const serializer = new XMLSerializer();
-    let source = serializer.serializeToString(svgElement);
-    source = '<?xml version="1.0" standalone="no"?>\r\n' + source;
-
-    const url = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(source);
-
-    const downloadLink = document.createElement("a");
-    downloadLink.href = url;
-    downloadLink.download = "scatter-plot-matrix.svg";
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
+    try {
+      const blob = await renderMatrixToPngBlob(svgElement, canvasContainer, 2);
+      downloadBlob(blob, 'scatter-plot-matrix.png');
+    } catch (err) {
+      alert(`PNG export failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   };
 
   // Build grouped column list for rendering
@@ -761,11 +758,11 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
 
       <PanelSection title="Export">
         <button
-          onClick={handleDownloadSVG}
+          onClick={handleDownloadPNG}
           className="w-full px-4 py-2 bg-brand-secondary text-white font-semibold rounded-lg shadow-md hover:bg-brand-primary transition-colors flex items-center justify-center space-x-2"
         >
           <DownloadIcon className="h-5 w-5" />
-          <span>Download SVG</span>
+          <span>Download PNG</span>
         </button>
       </PanelSection>
     </div>

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -1628,6 +1628,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       {/* Canvas container for high-performance point rendering */}
       <div
         ref={canvasContainerRef}
+        id="scatterplot-matrix-canvases"
         style={{
           position: 'absolute',
           top: 0,

--- a/src/test/exportPng.test.ts
+++ b/src/test/exportPng.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { collectCanvasPlacements, svgToDataUrl } from '../utils/exportPng';
+
+describe('collectCanvasPlacements', () => {
+  it('reads left/top from canvas inline styles', () => {
+    const container = document.createElement('div');
+    const c1 = document.createElement('canvas');
+    c1.style.left = '150px';
+    c1.style.top = '300px';
+    const c2 = document.createElement('canvas'); // no position set
+    container.append(c1, c2);
+
+    const placements = collectCanvasPlacements(container);
+    expect(placements).toHaveLength(2);
+    expect(placements[0]).toMatchObject({ left: 150, top: 300 });
+    expect(placements[1]).toMatchObject({ left: 0, top: 0 });
+  });
+
+  it('ignores non-canvas children', () => {
+    const container = document.createElement('div');
+    container.appendChild(document.createElement('div'));
+    expect(collectCanvasPlacements(container)).toHaveLength(0);
+  });
+});
+
+describe('svgToDataUrl', () => {
+  it('produces a data URL with the xmlns needed for standalone rasterization', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
+    svg.setAttribute('width', '300');
+    const url = svgToDataUrl(svg);
+    expect(url.startsWith('data:image/svg+xml;charset=utf-8,')).toBe(true);
+    const decoded = decodeURIComponent(url.split(',')[1]);
+    expect(decoded).toContain('xmlns="http://www.w3.org/2000/svg"');
+    expect(decoded).toContain('width="300"');
+  });
+
+  it('does not mutate the original element', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg') as SVGSVGElement;
+    svgToDataUrl(svg);
+    expect(svg.getAttribute('xmlns:xlink')).toBeNull();
+    expect(svg.style.fontFamily).toBe('');
+  });
+});

--- a/src/utils/exportPng.ts
+++ b/src/utils/exportPng.ts
@@ -1,0 +1,89 @@
+// PNG export for the scatter-plot matrix. The points are painted on Canvas
+// layers (for performance), while the SVG holds axes, labels, histograms and
+// overlays — so serializing the SVG alone exports a plot with no points.
+// Instead we composite: white background → cell canvases → SVG, at an
+// upscaled resolution, and hand back a PNG blob.
+
+export interface CanvasPlacement {
+  canvas: HTMLCanvasElement;
+  left: number;
+  top: number;
+}
+
+export function collectCanvasPlacements(container: HTMLElement): CanvasPlacement[] {
+  return Array.from(container.querySelectorAll('canvas')).map(canvas => ({
+    canvas,
+    left: parseFloat(canvas.style.left) || 0,
+    top: parseFloat(canvas.style.top) || 0,
+  }));
+}
+
+export function svgToDataUrl(svgEl: SVGSVGElement): string {
+  const clone = svgEl.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  clone.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+  // Text styling is inherited from the page CSS, which a standalone SVG
+  // loses — inline the computed font so labels keep their face and size.
+  if (typeof window !== 'undefined' && svgEl.isConnected) {
+    const cs = window.getComputedStyle(svgEl);
+    clone.style.fontFamily = cs.fontFamily;
+    clone.style.fontSize = cs.fontSize;
+  }
+  const source = new XMLSerializer().serializeToString(clone);
+  return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(source);
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to rasterize the SVG layer.'));
+    img.src = url;
+  });
+}
+
+export async function renderMatrixToPngBlob(
+  svgEl: SVGSVGElement,
+  canvasContainer: HTMLElement,
+  scale = 2
+): Promise<Blob> {
+  const width = Number(svgEl.getAttribute('width')) || svgEl.clientWidth;
+  const height = Number(svgEl.getAttribute('height')) || svgEl.clientHeight;
+  if (!width || !height) throw new Error('Matrix has no size to export.');
+
+  const out = document.createElement('canvas');
+  out.width = Math.round(width * scale);
+  out.height = Math.round(height * scale);
+  const ctx = out.getContext('2d');
+  if (!ctx) throw new Error('Could not create an export canvas context.');
+
+  ctx.scale(scale, scale);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+
+  // Points first (they sit under the SVG in the DOM), then the SVG overlay.
+  for (const { canvas, left, top } of collectCanvasPlacements(canvasContainer)) {
+    if (canvas.width === 0 || canvas.height === 0) continue;
+    ctx.drawImage(canvas, left, top, canvas.width, canvas.height);
+  }
+  const svgImage = await loadImage(svgToDataUrl(svgEl));
+  ctx.drawImage(svgImage, 0, 0, width, height);
+
+  return new Promise((resolve, reject) => {
+    out.toBlob(
+      blob => (blob ? resolve(blob) : reject(new Error('PNG encoding failed.'))),
+      'image/png'
+    );
+  });
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Reported by Dan: exported SVGs had no points. Structural, not a regression — points live on Canvas layers (the app's core perf architecture), the SVG only carries axes/labels/histograms, so SVG serialization could never include them.

Fix: `renderMatrixToPngBlob()` composites white background → cell canvases (at their absolute positions) → rasterized SVG overlay, at 2x scale, and downloads a PNG. Inlines the computed font on the SVG clone so labels survive standalone rasterization. Button is now 'Download PNG'.

Verified against the production build in headless Chromium: 12 canvases composited, 13k+ sampled point-pixels in the output, ~468KB. 285/285 tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PNG export for the scatter plot matrix, including the plotted points and chart overlay.
  * Updated the export action to download a `.png` file instead of SVG.
  * Added support for generating a higher-resolution image for cleaner downloads.

* **Bug Fixes**
  * Improved export reliability by handling missing chart elements with a clear alert before downloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->