### PR TITLE
fix: make diagonal column labels visually distinct from points

### DIFF
--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -217,7 +217,7 @@ const DraggableHeader: React.FC<{
       ) : isOver ? (
         <span className="font-bold text-brand-primary p-2 text-center break-all">Drop here</span>
       ) : (
-        <span className="font-bold text-brand-dark p-2 text-center break-all">
+        <span className="font-bold text-teal-800 bg-teal-50/90 rounded px-2 py-1 text-center break-all">
           {name}
           {isRainbowOrderColumn && (
             <span className="block text-[10px] font-semibold text-purple-600 uppercase tracking-wide">


### PR DESCRIPTION
Reported by Dan while demoing the scrum dataset: labels were `text-brand-dark` (#1e3a8a) — virtually the same hue as the point blue (#1e40af) — so when the matrix overflows the viewport the diagonal vanishes into the point noise. Labels are now teal-800 on a translucent teal-50 chip: teal is the one hue family no plot element uses, and the chip keeps labels readable over dense clouds. Verified visually in headless Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the drag state indicator to use a teal text color and a teal-tinted background with rounded padding.
  * Improved the appearance of the “Moving...” label shown during column drag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->