### PR TITLE
perf: columnar typed-array store for hot render paths

### DIFF
--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -372,7 +372,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   // truth everywhere else (stacked histograms, regression fits, table…).
   // Keyed by column NAMES (not Column identity) so visibility/scale edits —
   // which produce new Column objects with the same names — never rebuild it.
-  const columnNamesKey = useMemo(() => columns.map(c => c.name).join(''), [columns]);
+  const columnNamesKey = useMemo(() => columns.map(c => c.name).join('\u0001'), [columns]);
   const columnStore = useMemo(
     () => buildColumnStore(data, columns.map(c => c.name)),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- columnNamesKey stands in for columns

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -4,7 +4,18 @@ import { useDrag, useDrop } from 'react-dnd';
 import type { DataPoint, Column, BrushSelection, FilterMode } from '../types';
 import { mapVisibleColumns } from '../src/utils/columnUtils';
 import { filterData } from '../src/utils/dataUtils';
-import { computeSelectedStateHash, createSpatialGrid, getPointsInBrush } from '../src/utils/selectionUtils';
+import {
+  computeSelectedStateHash,
+  createSpatialGridFromColumns,
+  getPointsInBrushFromColumns,
+} from '../src/utils/selectionUtils';
+import {
+  buildColumnStore,
+  buildSelectedFlags,
+  computeVectorStats,
+  collectFiniteValues,
+  selectIdsInValueRange,
+} from '../src/utils/columnStore';
 import { ImageDataLRU, totalSnapshotBytes } from '../src/utils/imageDataCache';
 import { cellValueToNumber } from '../src/utils/cellValueUtils';
 import { MISSING_COLOR, MISSING_SLOT } from '../src/utils/colorUtils';
@@ -353,12 +364,48 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     return brushSelection?.selectedIds || new Set<number>();
   }, [brushSelection]);
 
-  // Canvas rendering function
-  const renderPointsToCanvas = useCallback((canvas: HTMLCanvasElement, data: DataPoint[], xScale: d3.ScaleLinear<number, number>, yScale: d3.ScaleLinear<number, number>, xCol: string, yCol: string, selectedIds: Set<number>, filterMode: FilterMode) => {
+  // Columnar typed-array store over the rendered dataset: one Float64Array
+  // per column (NaN = missing) plus per-column min/max/minPositive from the
+  // same single build pass. The hot paths below (point paint loops, scale
+  // stats, spatial-grid brush queries, histogram extraction) read this store
+  // instead of walking row objects; the row objects remain the source of
+  // truth everywhere else (stacked histograms, regression fits, table…).
+  // Keyed by column NAMES (not Column identity) so visibility/scale edits —
+  // which produce new Column objects with the same names — never rebuild it.
+  const columnNamesKey = useMemo(() => columns.map(c => c.name).join(''), [columns]);
+  const columnStore = useMemo(
+    () => buildColumnStore(data, columns.map(c => c.name)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- columnNamesKey stands in for columns
+    [data, columnNamesKey]
+  );
+
+  // Per-store-row selection flags (1 = selected); null when nothing is
+  // selected. O(n) rebuild per selection change, then every paint loop gets
+  // branch-cheap Uint8Array reads instead of Set.has per point per cell.
+  const selectedFlags = useMemo(
+    () => buildSelectedFlags(columnStore, selectedIds),
+    [columnStore, selectedIds]
+  );
+
+  // Canvas rendering function: paints one cell's points from the columnar
+  // store. Iterates store rows (== the matrix's dataset, faceting included);
+  // filter-mode subsetting and highlight-mode dimming are driven by
+  // selectedFlags, matching the previous row-object behavior exactly.
+  const renderPointsToCanvas = useCallback((
+    canvas: HTMLCanvasElement,
+    xValues: Float64Array,
+    yValues: Float64Array,
+    xScale: d3.ScaleLinear<number, number>,
+    yScale: d3.ScaleLinear<number, number>
+  ) => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
     ctx.clearRect(0, 0, size, size);
+
+    const rowCount = columnStore.length;
+    const { rowIds } = columnStore;
+    const hasSelection = selectedFlags !== null;
 
     if (colorState) {
       // Color-by paint path. The per-row color slot was precomputed once per
@@ -369,99 +416,91 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       // regardless of row count.
       const { slotById, slotColors } = colorState;
       const numSlots = slotColors.length;
-      const hasSelection = selectedIds.size > 0;
 
       // Flat coordinate buffers per slot; last bucket = missing/NaN rows.
       const coloredCoords: number[][] = Array.from({ length: numSlots + 1 }, () => []);
-      const selectedCoords: number[][] = hasSelection
-        ? Array.from({ length: numSlots + 1 }, () => [])
-        : coloredCoords;
       const dimmedCoords: number[] = [];
 
-      for (const d of data) {
-        const x = cellValueToNumber(d[xCol]);
-        const y = cellValueToNumber(d[yCol]);
-        if (!isFinite(x) || !isFinite(y)) continue;
+      for (let i = 0; i < rowCount; i++) {
+        const x = xValues[i];
+        const y = yValues[i];
+        // NaN self-compare — store values are finite or NaN by construction.
+        if (x !== x || y !== y) continue;
 
-        const screenX = xScale(x);
-        const screenY = yScale(y);
-        const isSelected = hasSelection && selectedIds.has(d.__id);
-
-        if (hasSelection && !isSelected) {
+        if (hasSelection && !selectedFlags[i]) {
           // Unselected points keep the classic dimmed-gray treatment so the
-          // selection stays readable even with many colors on screen.
-          if (filterMode === 'highlight') dimmedCoords.push(screenX, screenY);
+          // selection stays readable even with many colors on screen; in
+          // filter mode they are hidden entirely.
+          if (filterMode === 'highlight') dimmedCoords.push(xScale(x), yScale(y));
           continue;
         }
 
         // slot is undefined when __id is out of slotById's bounds (e.g. a
         // transient render where colorState lags a data swap); undefined
         // fails both sentinel checks, so guard it explicitly to avoid
-        // selectedCoords[undefined].push crashing the paint loop.
-        const slot = slotById[d.__id];
+        // coloredCoords[undefined].push crashing the paint loop.
+        const slot = slotById[rowIds[i]];
         const bucket = slot === undefined || slot === MISSING_SLOT || slot >= numSlots
           ? numSlots
           : slot;
-        selectedCoords[bucket].push(screenX, screenY);
+        coloredCoords[bucket].push(xScale(x), yScale(y));
       }
 
       drawPointBatch(ctx, dimmedCoords, '#ccc', 0.3);
       const alpha = hasSelection ? 0.8 : 0.7;
       for (let s = 0; s < numSlots; s++) {
-        drawPointBatch(ctx, selectedCoords[s], slotColors[s], alpha);
+        drawPointBatch(ctx, coloredCoords[s], slotColors[s], alpha);
       }
-      drawPointBatch(ctx, selectedCoords[numSlots], MISSING_COLOR, alpha);
+      drawPointBatch(ctx, coloredCoords[numSlots], MISSING_COLOR, alpha);
 
       ctx.globalAlpha = 1;
       return;
     }
 
-    // Render non-selected points first
-    if (filterMode === 'highlight' || selectedIds.size === 0) {
-      ctx.fillStyle = selectedIds.size > 0 ? '#ccc' : '#4b5563';
-      ctx.globalAlpha = selectedIds.size > 0 ? 0.3 : 0.7;
+    // Render non-selected points first. Kept as one arc + fill per point
+    // (not a batched path): with globalAlpha < 1, overlapping points darken
+    // under per-point fills but would not inside a single path — batching
+    // here would visibly change dense clouds.
+    if (filterMode === 'highlight' || !hasSelection) {
+      ctx.fillStyle = hasSelection ? '#ccc' : '#4b5563';
+      ctx.globalAlpha = hasSelection ? 0.3 : 0.7;
 
-      data.forEach(d => {
-        if (selectedIds.size > 0 && selectedIds.has(d.__id)) return;
-
-        const x = cellValueToNumber(d[xCol]);
-        const y = cellValueToNumber(d[yCol]);
-        if (!isFinite(x) || !isFinite(y)) return;
-
-        const screenX = xScale(x);
-        const screenY = yScale(y);
+      for (let i = 0; i < rowCount; i++) {
+        if (hasSelection && selectedFlags[i]) continue;
+        const x = xValues[i];
+        const y = yValues[i];
+        if (x !== x || y !== y) continue;
 
         ctx.beginPath();
-        ctx.arc(screenX, screenY, 2.5, 0, 2 * Math.PI);
+        ctx.arc(xScale(x), yScale(y), 2.5, 0, 2 * Math.PI);
         ctx.fill();
-      });
+      }
     }
 
     // Render selected points on top
-    if (selectedIds.size > 0) {
+    if (hasSelection) {
       ctx.fillStyle = '#1e40af';
       ctx.globalAlpha = 0.8;
 
-      data.forEach(d => {
-        if (!selectedIds.has(d.__id)) return;
-
-        const x = cellValueToNumber(d[xCol]);
-        const y = cellValueToNumber(d[yCol]);
-        if (!isFinite(x) || !isFinite(y)) return;
-
-        const screenX = xScale(x);
-        const screenY = yScale(y);
+      for (let i = 0; i < rowCount; i++) {
+        if (!selectedFlags[i]) continue;
+        const x = xValues[i];
+        const y = yValues[i];
+        if (x !== x || y !== y) continue;
 
         ctx.beginPath();
-        ctx.arc(screenX, screenY, 2.5, 0, 2 * Math.PI);
+        ctx.arc(xScale(x), yScale(y), 2.5, 0, 2 * Math.PI);
         ctx.fill();
-      });
+      }
     }
 
     ctx.globalAlpha = 1;
-  }, [size, colorState]);
+  }, [size, colorState, columnStore, selectedFlags, filterMode]);
 
-  const { filteredData, selectedData } = useMemo(
+  // filteredData still feeds the row-object consumers (stacked histograms,
+  // regression/correlation fits); the point/histogram hot paths read the
+  // columnar store + selectedFlags instead.
+  const { filteredData } = useMemo(
     () => filterData(data, selectedIds, filterMode),
     [data, selectedIds, filterMode]
   );
@@ -674,32 +713,23 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     ctx.globalAlpha = 1;
   }, [showIdentityLine, showRegressionLine, showCorrelation, correlationMetric, tintCellBorders, size, padding, dataStateHash, filterMode, selectedStateHash]);
 
-  // Compute stats from appropriate dataset: filtered data when in filter mode with selection, otherwise full data
-  const dataForStats = useMemo(() => {
-    return (filterMode === 'filter' && selectedIds.size > 0) ? filteredData : data;
-  }, [filterMode, selectedIds.size, filteredData, data]);
-
+  // Scale-domain stats from the columnar store. Full-data stats were already
+  // computed during the store's single build pass; only filter mode with an
+  // active selection needs a (flag-restricted) rescan, matching the previous
+  // "stats over filteredData" behavior.
   const columnStats = useMemo(() => {
     const stats = new Map<string, { min: number; max: number; minPositive: number }>();
+    const flagsForStats = filterMode === 'filter' ? selectedFlags : null;
+
     visibleColumns.forEach(col => {
-      stats.set(col.name, { min: Infinity, max: -Infinity, minPositive: Infinity });
+      const vector = columnStore.columns.get(col.name);
+      stats.set(
+        col.name,
+        vector
+          ? computeVectorStats(vector, flagsForStats)
+          : { min: Infinity, max: -Infinity, minPositive: Infinity }
+      );
     });
-
-    if (visibleColumns.length === 0) {
-      return stats;
-    }
-
-    for (const row of dataForStats) {
-      for (const col of visibleColumns) {
-        const value = cellValueToNumber(row[col.name]);
-        if (!isFinite(value)) continue;
-        const columnStat = stats.get(col.name);
-        if (!columnStat) continue;
-        if (value < columnStat.min) columnStat.min = value;
-        if (value > columnStat.max) columnStat.max = value;
-        if (value > 0 && value < columnStat.minPositive) columnStat.minPositive = value;
-      }
-    }
 
     visibleColumns.forEach(col => {
       const stat = stats.get(col.name);
@@ -714,7 +744,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     });
 
     return stats;
-  }, [dataForStats, visibleColumns]);
+  }, [columnStore, selectedFlags, filterMode, visibleColumns]);
 
   const createScale = useCallback(
     (column: Column, range: [number, number]) => {
@@ -920,9 +950,13 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         const colY = columns[j_original];
         if (!colX || !colY) return;
 
-        // Create spatial grid for fast selection
-        const grid = createSpatialGrid(data, xScales[i_visible], yScales[j_visible], colX.name, colY.name, size);
-        const newSelectedIds = getPointsInBrush(grid, xScales[i_visible], yScales[j_visible], x0, y0, x1, y1, colX.name, colY.name, size);
+        // Create spatial grid for fast selection (columnar: typed-array
+        // coordinate reads, no per-row object access)
+        const xVector = columnStore.columns.get(colX.name);
+        const yVector = columnStore.columns.get(colY.name);
+        if (!xVector || !yVector) return;
+        const grid = createSpatialGridFromColumns(xVector.values, yVector.values, xScales[i_visible], yScales[j_visible], size);
+        const newSelectedIds = getPointsInBrushFromColumns(grid, xVector.values, yVector.values, columnStore.rowIds, xScales[i_visible], yScales[j_visible], x0, y0, x1, y1, size);
         onBrush({ indexX: i_original, indexY: j_original, x0, y0, x1, y1, selectedIds: newSelectedIds });
       });
 
@@ -947,6 +981,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       yColName: string;
       xLog: boolean;
       yLog: boolean;
+      xValues: Float64Array;
+      yValues: Float64Array;
     }
     const paintTasks: PaintTask[] = [];
 
@@ -1022,6 +1058,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           ctx.putImageData(cached, 0, 0);
           canvasRenderKeyRef.current.set(canvasKey, renderKey);
         } else {
+          const xVector = columnStore.columns.get(colX.name);
+          const yVector = columnStore.columns.get(colY.name);
+          if (!xVector || !yVector) return;
           paintTasks.push({
             canvas,
             canvasKey,
@@ -1032,6 +1071,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
             yColName: colY.name,
             xLog: colX.scale === 'log',
             yLog: colY.scale === 'log',
+            xValues: xVector.values,
+            yValues: yVector.values,
           });
         }
       }
@@ -1135,14 +1176,14 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           if (!event.selection) { onBrush(null); return; }
 
           const [x0, x1] = event.selection;
-          // Faster selection for histogram brush
-          const newSelectedIds = new Set<number>();
+          // Columnar histogram brush: scan one Float64Array. Missing cells
+          // are NaN and never match (the old `+row[col]` coercion turned
+          // them into 0, silently selecting sparse rows when 0 was in range).
+          const vector = columnStore.columns.get(columns[i_original].name);
+          if (!vector) return;
           const minVal = xScales[i_visible].invert(x0);
           const maxVal = xScales[i_visible].invert(x1);
-          for (const d of data) {
-            const val = +d[columns[i_original].name];
-            if (val >= minVal && val <= maxVal) newSelectedIds.add(d.__id);
-          }
+          const newSelectedIds = selectIdsInValueRange(columnStore, vector, minVal, maxVal);
           onBrush({ indexX: i_original, indexY: columns.length, x0, y0: padding / 2, x1, y1: size - padding / 2, selectedIds: newSelectedIds });
         });
 
@@ -1220,8 +1261,16 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           return;
         }
 
-        const allValues = filteredData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
-        const selectedValues = selectedData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
+        // Columnar histogram extraction: finite values straight from the
+        // store (filter mode restricts to the selected rows, mirroring the
+        // old filteredData/selectedData row scans).
+        const histVector = columnStore.columns.get(column.name);
+        const allValues = histVector
+          ? collectFiniteValues(histVector, filterMode === 'filter' ? selectedFlags : null)
+          : [];
+        const selectedValues = histVector && selectedFlags
+          ? collectFiniteValues(histVector, selectedFlags)
+          : [];
 
         const binGeneratorBase = d3.bin().domain([minDomain, maxDomain]);
         const binGenerator = Array.isArray(thresholds)
@@ -1309,14 +1358,13 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           if (!event.selection) { onBrush(null); return; }
 
           const [y0, y1] = event.selection;
-          const newSelectedIds = new Set<number>();
-          // Faster selection for Y histogram brush
+          // Columnar histogram brush; see the bottom-histogram handler for
+          // the NaN/missing-cell rationale.
+          const vector = columnStore.columns.get(columns[j_original].name);
+          if (!vector) return;
           const minVal = yScales[j_visible].invert(y1);
           const maxVal = yScales[j_visible].invert(y0);
-          for (const d of data) {
-            const val = +d[columns[j_original].name];
-            if (val >= minVal && val <= maxVal) newSelectedIds.add(d.__id);
-          }
+          const newSelectedIds = selectIdsInValueRange(columnStore, vector, minVal, maxVal);
           onBrush({ indexX: columns.length, indexY: j_original, x0: padding / 2, y0, x1: size - padding / 2, y1, selectedIds: newSelectedIds });
         });
 
@@ -1389,8 +1437,16 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           return;
         }
 
-        const allValues = filteredData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
-        const selectedValues = selectedData.map(d => cellValueToNumber(d[column.name])).filter(isFinite);
+        // Columnar histogram extraction: finite values straight from the
+        // store (filter mode restricts to the selected rows, mirroring the
+        // old filteredData/selectedData row scans).
+        const histVector = columnStore.columns.get(column.name);
+        const allValues = histVector
+          ? collectFiniteValues(histVector, filterMode === 'filter' ? selectedFlags : null)
+          : [];
+        const selectedValues = histVector && selectedFlags
+          ? collectFiniteValues(histVector, selectedFlags)
+          : [];
 
         const binGeneratorBase = d3.bin().domain([minDomain, maxDomain]);
         const binGenerator = Array.isArray(thresholds)
@@ -1511,13 +1567,10 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         const task = paintTasks[tasksDone];
         renderPointsToCanvas(
           task.canvas,
-          filteredData,
+          task.xValues,
+          task.yValues,
           task.xScale,
-          task.yScale,
-          task.xColName,
-          task.yColName,
-          selectedIds,
-          filterMode
+          task.yScale
         );
         // Reference-line overlay: a separate draw step after the point pass,
         // still inside the same task so snapshots capture the full cell.
@@ -1565,7 +1618,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (timeoutId !== null) clearTimeout(timeoutId);
     };
-  }, [data, columns, onBrush, filteredData, selectedData, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, drawReferenceLines, showIdentityLine, showRegressionLine, showCorrelation, tintCellBorders, correlationMetric, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, colorState, onRenderComplete, onRenderProgress]);
+  }, [data, columns, onBrush, filteredData, columnStore, selectedFlags, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, drawReferenceLines, showIdentityLine, showRegressionLine, showCorrelation, tintCellBorders, correlationMetric, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, colorState, onRenderComplete, onRenderProgress]);
 
   return (
     <div

--- a/src/test/columnStore.test.ts
+++ b/src/test/columnStore.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import type { DataPoint } from '../../types';
+import {
+  buildColumnStore,
+  buildSelectedFlags,
+  computeVectorStats,
+  collectFiniteValues,
+  selectIdsInValueRange,
+} from '../utils/columnStore';
+import {
+  createSpatialGrid,
+  getPointsInBrush,
+  createSpatialGridFromColumns,
+  getPointsInBrushFromColumns,
+} from '../utils/selectionUtils';
+
+// Matches the perf-test convention: local thresholds are the target, CI
+// runners get headroom.
+const CI_FACTOR = process.env.CI ? 8 : 1;
+
+function makeRows(rows: number, cols: number, missingEvery = 0): DataPoint[] {
+  return Array.from({ length: rows }, (_, i) => {
+    const row: DataPoint = { __id: i };
+    for (let c = 0; c < cols; c++) {
+      row[`col_${c}`] =
+        missingEvery > 0 && (i + c) % missingEvery === 0 ? '' : (i * 31 + c * 7) % 997;
+    }
+    return row;
+  });
+}
+
+describe('buildColumnStore', () => {
+  const data: DataPoint[] = [
+    { __id: 0, a: 5, b: -2, s: 'x' },
+    { __id: 1, a: '3.5', b: null as unknown as number, s: 'y' },
+    { __id: 2, a: '', b: 0.25, s: 'z' },
+    { __id: 3, a: 'abc', b: 10, s: 'w' },
+    { __id: 4, a: 0, b: '  ', s: 'v' },
+  ];
+
+  it('stores numeric values with NaN for missing/blank/non-numeric cells', () => {
+    const store = buildColumnStore(data, ['a', 'b']);
+    expect(store.length).toBe(5);
+    expect(Array.from(store.columns.get('a')!.values.slice(0, 2))).toEqual([5, 3.5]);
+    expect(store.columns.get('a')!.values[2]).toBeNaN(); // ''
+    expect(store.columns.get('a')!.values[3]).toBeNaN(); // 'abc'
+    expect(store.columns.get('a')!.values[4]).toBe(0);
+    expect(store.columns.get('b')!.values[1]).toBeNaN(); // null
+    expect(store.columns.get('b')!.values[4]).toBeNaN(); // blank string
+  });
+
+  it('maps store rows to __ids via rowIds (array order, not id order)', () => {
+    const shuffled = [data[3], data[0], data[4]];
+    const store = buildColumnStore(shuffled, ['a']);
+    expect(Array.from(store.rowIds)).toEqual([3, 0, 4]);
+    expect(store.columns.get('a')!.values[1]).toBe(5); // row __id 0
+  });
+
+  it('computes min/max/minPositive/finiteCount in the build pass', () => {
+    const store = buildColumnStore(data, ['a', 'b']);
+    const a = store.columns.get('a')!;
+    expect(a.min).toBe(0);
+    expect(a.max).toBe(5);
+    expect(a.minPositive).toBe(3.5);
+    expect(a.finiteCount).toBe(3);
+    const b = store.columns.get('b')!;
+    expect(b.min).toBe(-2);
+    expect(b.max).toBe(10);
+    expect(b.minPositive).toBe(0.25);
+    expect(b.finiteCount).toBe(3);
+  });
+
+  it('yields Infinity sentinels for a column with no finite values', () => {
+    const store = buildColumnStore(data, ['s']);
+    const s = store.columns.get('s')!;
+    expect(s.min).toBe(Infinity);
+    expect(s.max).toBe(-Infinity);
+    expect(s.minPositive).toBe(Infinity);
+    expect(s.finiteCount).toBe(0);
+  });
+
+  it('deduplicates repeated column names', () => {
+    const store = buildColumnStore(data, ['a', 'a', 'b']);
+    expect(store.columns.size).toBe(2);
+  });
+
+  it('matches the legacy per-render row-scan stats on random data', () => {
+    const rows = makeRows(2000, 3, 7);
+    const store = buildColumnStore(rows, ['col_0', 'col_1', 'col_2']);
+    for (const name of ['col_0', 'col_1', 'col_2']) {
+      let min = Infinity, max = -Infinity, minPositive = Infinity;
+      for (const row of rows) {
+        const v = +row[name];
+        if (row[name] === '' || !Number.isFinite(v)) continue;
+        if (v < min) min = v;
+        if (v > max) max = v;
+        if (v > 0 && v < minPositive) minPositive = v;
+      }
+      const vec = store.columns.get(name)!;
+      expect(vec.min).toBe(min);
+      expect(vec.max).toBe(max);
+      expect(vec.minPositive).toBe(minPositive);
+    }
+  });
+});
+
+describe('buildSelectedFlags / computeVectorStats / collectFiniteValues', () => {
+  const rows = makeRows(100, 2, 9);
+  const store = buildColumnStore(rows, ['col_0', 'col_1']);
+
+  it('returns null for an empty selection', () => {
+    expect(buildSelectedFlags(store, new Set())).toBeNull();
+  });
+
+  it('flags exactly the selected store rows', () => {
+    const flags = buildSelectedFlags(store, new Set([2, 50, 99]))!;
+    expect(flags.length).toBe(100);
+    expect(flags[2]).toBe(1);
+    expect(flags[50]).toBe(1);
+    expect(flags[99]).toBe(1);
+    expect(Array.from(flags).reduce((a, b) => a + b, 0)).toBe(3);
+  });
+
+  it('computeVectorStats(null flags) returns the prebuilt full-column stats', () => {
+    const vec = store.columns.get('col_0')!;
+    expect(computeVectorStats(vec, null)).toEqual({
+      min: vec.min,
+      max: vec.max,
+      minPositive: vec.minPositive,
+    });
+  });
+
+  it('computeVectorStats over a flagged subset matches a manual scan', () => {
+    const ids = new Set([1, 3, 5, 7, 11]);
+    const flags = buildSelectedFlags(store, ids)!;
+    const vec = store.columns.get('col_1')!;
+    const subsetVals = rows
+      .filter(r => ids.has(r.__id) && r['col_1'] !== '')
+      .map(r => +r['col_1']);
+    const stats = computeVectorStats(vec, flags);
+    expect(stats.min).toBe(Math.min(...subsetVals));
+    expect(stats.max).toBe(Math.max(...subsetVals));
+  });
+
+  it('collectFiniteValues skips NaN and honors flags', () => {
+    const vec = store.columns.get('col_0')!;
+    const all = collectFiniteValues(vec);
+    expect(all.length).toBe(vec.finiteCount);
+    expect(all.every(Number.isFinite)).toBe(true);
+
+    const flags = buildSelectedFlags(store, new Set([0, 1, 2]))!;
+    const some = collectFiniteValues(vec, flags);
+    const expected = rows.slice(0, 3).filter(r => r['col_0'] !== '').length;
+    expect(some.length).toBe(expected);
+  });
+});
+
+describe('selectIdsInValueRange', () => {
+  it('selects ids by value range and never matches NaN (missing) cells', () => {
+    const rows: DataPoint[] = [
+      { __id: 0, v: 0 },
+      { __id: 1, v: 5 },
+      { __id: 2, v: '' },     // old +coercion would have made this 0
+      { __id: 3, v: 10 },
+      { __id: 4, v: null as unknown as number },
+    ];
+    const store = buildColumnStore(rows, ['v']);
+    const vec = store.columns.get('v')!;
+    expect(selectIdsInValueRange(store, vec, 0, 5)).toEqual(new Set([0, 1]));
+    expect(selectIdsInValueRange(store, vec, -100, 100)).toEqual(new Set([0, 1, 3]));
+  });
+});
+
+describe('columnar spatial grid parity', () => {
+  it('matches the row-object grid/brush results exactly', () => {
+    const rows = makeRows(3000, 2, 13);
+    const store = buildColumnStore(rows, ['col_0', 'col_1']);
+    const size = 150;
+    const xScale = (v: number) => (v / 997) * size;
+    const yScale = (v: number) => size - (v / 997) * size;
+
+    const legacyGrid = createSpatialGrid(rows, xScale, yScale, 'col_0', 'col_1', size);
+    const legacyIds = getPointsInBrush(
+      legacyGrid, xScale, yScale, 20, 30, 90, 120, 'col_0', 'col_1', size
+    );
+
+    const xVec = store.columns.get('col_0')!.values;
+    const yVec = store.columns.get('col_1')!.values;
+    const grid = createSpatialGridFromColumns(xVec, yVec, xScale, yScale, size);
+    const ids = getPointsInBrushFromColumns(
+      grid, xVec, yVec, store.rowIds, xScale, yScale, 20, 30, 90, 120, size
+    );
+
+    expect(ids).toEqual(legacyIds);
+    expect(ids.size).toBeGreaterThan(0);
+  });
+});
+
+describe('column store performance', () => {
+  it('builds a 30k x 30 store (with stats) in under 150ms', () => {
+    const rows = makeRows(30000, 30);
+    const names = Array.from({ length: 30 }, (_, c) => `col_${c}`);
+    const start = performance.now();
+    const store = buildColumnStore(rows, names);
+    const elapsed = performance.now() - start;
+    expect(store.length).toBe(30000);
+    expect(store.columns.size).toBe(30);
+    expect(elapsed).toBeLessThan(150 * CI_FACTOR);
+  });
+
+  it('rebuilds selection flags for 30k rows in under 20ms', () => {
+    const rows = makeRows(30000, 1);
+    const store = buildColumnStore(rows, ['col_0']);
+    const selected = new Set(Array.from({ length: 10000 }, (_, i) => i * 3));
+    const start = performance.now();
+    const flags = buildSelectedFlags(store, selected)!;
+    const elapsed = performance.now() - start;
+    expect(flags.reduce((a: number, b) => a + b, 0)).toBe(10000);
+    expect(elapsed).toBeLessThan(20 * CI_FACTOR);
+  });
+});

--- a/src/test/columnStore.test.ts
+++ b/src/test/columnStore.test.ts
@@ -140,6 +140,24 @@ describe('buildSelectedFlags / computeVectorStats / collectFiniteValues', () => 
     const stats = computeVectorStats(vec, flags);
     expect(stats.min).toBe(Math.min(...subsetVals));
     expect(stats.max).toBe(Math.max(...subsetVals));
+    expect(stats.minPositive).toBe(Math.min(...subsetVals.filter(v => v > 0)));
+  });
+
+  it('computeVectorStats minPositive over a flagged subset ignores zero/negative values', () => {
+    const negRows: DataPoint[] = [
+      { __id: 0, v: -5 },
+      { __id: 1, v: 0 },
+      { __id: 2, v: 4 },
+      { __id: 3, v: 2 },
+      { __id: 4, v: 0.5 }, // deliberately NOT flagged: must not become minPositive
+    ];
+    const s = buildColumnStore(negRows, ['v']);
+    const flags = buildSelectedFlags(s, new Set([0, 1, 2, 3]))!;
+    expect(computeVectorStats(s.columns.get('v')!, flags)).toEqual({
+      min: -5,
+      max: 4,
+      minPositive: 2,
+    });
   });
 
   it('collectFiniteValues skips NaN and honors flags', () => {

--- a/src/utils/columnStore.ts
+++ b/src/utils/columnStore.ts
@@ -1,0 +1,181 @@
+import type { DataPoint } from '../../types';
+import { cellValueToNumber } from './cellValueUtils';
+
+/**
+ * Columnar typed-array storage for the hot render paths (ROADMAP:
+ * "Columnar typed-array storage").
+ *
+ * Row objects (`DataPoint[]`) remain the source of truth for the table,
+ * tooltips, PCA, facets and CSV round-trips; this store is a derived,
+ * memoized view used by the per-frame code: point paint loops, scale-domain
+ * stats, spatial-grid brush queries and histogram value extraction. One
+ * `Float64Array` per numeric column removes the per-point property lookup +
+ * string-coercion (`cellValueToNumber`) cost from those loops, and per-column
+ * min/max/minPositive fall out of the same single build pass — replacing the
+ * per-render row scan that previously computed scale domains.
+ *
+ * Layout: store row index == index into the `DataPoint[]` the store was
+ * built from; `rowIds[i]` is that row's `__id` (which spans the FULL dataset
+ * even when the store is built from a faceted subset).
+ *
+ * Missing-value semantics follow `cellValueUtils`: null / blank /
+ * non-numeric cells are stored as NaN (never 0), so sparse rows can neither
+ * paint at the origin nor be brush-selected as ghosts.
+ */
+
+export interface ColumnVector {
+  /** Per-row values in store-row order; NaN for missing/non-numeric cells. */
+  values: Float64Array;
+  /** Min over finite values; +Infinity when the column has none. */
+  min: number;
+  /** Max over finite values; -Infinity when the column has none. */
+  max: number;
+  /** Smallest strictly-positive finite value; +Infinity when none. */
+  minPositive: number;
+  /** Number of finite values in the column. */
+  finiteCount: number;
+}
+
+export interface ColumnStore {
+  /** Number of rows (== length of every vector and of rowIds). */
+  length: number;
+  /** rowIds[i] = __id of store row i. */
+  rowIds: Int32Array;
+  columns: Map<string, ColumnVector>;
+}
+
+/**
+ * Build a columnar store from row objects in a single pass over the data.
+ * `columnNames` are deduplicated; unknown cells simply come out as NaN.
+ */
+export function buildColumnStore(data: DataPoint[], columnNames: string[]): ColumnStore {
+  const n = data.length;
+  const rowIds = new Int32Array(n);
+  const columns = new Map<string, ColumnVector>();
+
+  const uniqueNames: string[] = [];
+  for (const name of columnNames) {
+    if (!columns.has(name)) {
+      uniqueNames.push(name);
+      columns.set(name, {
+        values: new Float64Array(n),
+        min: Infinity,
+        max: -Infinity,
+        minPositive: Infinity,
+        finiteCount: 0,
+      });
+    }
+  }
+
+  // Iterate rows outermost: one property-hash walk per row object stays
+  // cache-friendly and visits each row exactly once.
+  const vectors = uniqueNames.map(name => columns.get(name)!);
+  for (let i = 0; i < n; i++) {
+    const row = data[i];
+    rowIds[i] = row.__id;
+    for (let c = 0; c < uniqueNames.length; c++) {
+      const vec = vectors[c];
+      const value = cellValueToNumber(row[uniqueNames[c]]);
+      vec.values[i] = value;
+      if (value === value) { // finite by construction (NaN otherwise)
+        if (value < vec.min) vec.min = value;
+        if (value > vec.max) vec.max = value;
+        if (value > 0 && value < vec.minPositive) vec.minPositive = value;
+        vec.finiteCount++;
+      }
+    }
+  }
+
+  return { length: n, rowIds, columns };
+}
+
+/**
+ * Per-store-row selection flags: flags[i] = 1 iff rowIds[i] ∈ selectedIds.
+ * Returns null for an empty selection so callers can use `flags === null`
+ * as the fast "nothing selected" check.
+ */
+export function buildSelectedFlags(
+  store: ColumnStore,
+  selectedIds: Set<number>
+): Uint8Array | null {
+  if (selectedIds.size === 0) return null;
+  const { rowIds, length } = store;
+  const flags = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    if (selectedIds.has(rowIds[i])) flags[i] = 1;
+  }
+  return flags;
+}
+
+export interface VectorStats {
+  min: number;
+  max: number;
+  minPositive: number;
+}
+
+/**
+ * Min/max/minPositive over the flagged subset of a vector (used for
+ * filter-mode scale domains, where stats cover only the selected rows).
+ * Pass `flags = null` to get the precomputed full-column stats.
+ */
+export function computeVectorStats(
+  vector: ColumnVector,
+  flags: Uint8Array | null
+): VectorStats {
+  if (flags === null) {
+    return { min: vector.min, max: vector.max, minPositive: vector.minPositive };
+  }
+  const { values } = vector;
+  let min = Infinity;
+  let max = -Infinity;
+  let minPositive = Infinity;
+  for (let i = 0; i < values.length; i++) {
+    if (!flags[i]) continue;
+    const value = values[i];
+    if (value !== value) continue;
+    if (value < min) min = value;
+    if (value > max) max = value;
+    if (value > 0 && value < minPositive) minPositive = value;
+  }
+  return { min, max, minPositive };
+}
+
+/**
+ * Finite values of a column as a plain number[] (d3.bin input), optionally
+ * restricted to flagged rows. Replaces `rows.map(cellValueToNumber)
+ * .filter(isFinite)` in the histogram path.
+ */
+export function collectFiniteValues(
+  vector: ColumnVector,
+  flags: Uint8Array | null = null
+): number[] {
+  const { values } = vector;
+  const out: number[] = [];
+  for (let i = 0; i < values.length; i++) {
+    if (flags !== null && !flags[i]) continue;
+    const value = values[i];
+    if (value === value) out.push(value);
+  }
+  return out;
+}
+
+/**
+ * Ids of rows whose value in `vector` lies inside [min, max]. NaN (missing)
+ * never matches — the columnar replacement for the histogram-brush row scan
+ * (whose old `+row[col]` coercion silently treated missing cells as 0).
+ */
+export function selectIdsInValueRange(
+  store: ColumnStore,
+  vector: ColumnVector,
+  min: number,
+  max: number
+): Set<number> {
+  const { values } = vector;
+  const { rowIds } = store;
+  const selected = new Set<number>();
+  for (let i = 0; i < values.length; i++) {
+    const value = values[i];
+    if (value >= min && value <= max) selected.add(rowIds[i]);
+  }
+  return selected;
+}

--- a/src/utils/selectionUtils.ts
+++ b/src/utils/selectionUtils.ts
@@ -48,6 +48,76 @@ export function createSpatialGrid(
     return grid;
 }
 
+/**
+ * Columnar variant of createSpatialGrid: bins store-row indices instead of
+ * row objects, reading coordinates straight from per-column Float64Arrays
+ * (NaN = missing, skipped). Flat gridSize×gridSize layout, cell (gx, gy) at
+ * index gx * gridSize + gy.
+ */
+export function createSpatialGridFromColumns(
+    xValues: Float64Array,
+    yValues: Float64Array,
+    xScale: (v: number) => number,
+    yScale: (v: number) => number,
+    size: number,
+    gridSize = 20
+): number[][] {
+    const grid: number[][] = Array.from({ length: gridSize * gridSize }, () => []);
+    for (let i = 0; i < xValues.length; i++) {
+        const x = xValues[i];
+        const y = yValues[i];
+        // NaN self-compare: missing cells never enter the grid.
+        if (x !== x || y !== y) continue;
+        const sx = xScale(x);
+        const sy = yScale(y);
+        const gx = Math.floor((sx / size) * gridSize);
+        const gy = Math.floor((sy / size) * gridSize);
+        if (gx >= 0 && gx < gridSize && gy >= 0 && gy < gridSize) {
+            grid[gx * gridSize + gy].push(i);
+        }
+    }
+    return grid;
+}
+
+/**
+ * Columnar variant of getPointsInBrush: queries a grid of store-row indices
+ * and maps hits back to __ids via rowIds.
+ */
+export function getPointsInBrushFromColumns(
+    grid: number[][],
+    xValues: Float64Array,
+    yValues: Float64Array,
+    rowIds: Int32Array,
+    xScale: (v: number) => number,
+    yScale: (v: number) => number,
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    size: number,
+    gridSize = 20
+): Set<number> {
+    const selected = new Set<number>();
+    const startGX = Math.max(0, Math.floor((x0 / size) * gridSize));
+    const endGX = Math.min(gridSize - 1, Math.ceil((x1 / size) * gridSize));
+    const startGY = Math.max(0, Math.floor((y0 / size) * gridSize));
+    const endGY = Math.min(gridSize - 1, Math.ceil((y1 / size) * gridSize));
+    for (let gx = startGX; gx <= endGX; gx++) {
+        for (let gy = startGY; gy <= endGY; gy++) {
+            const cell = grid[gx * gridSize + gy];
+            for (let k = 0; k < cell.length; k++) {
+                const i = cell[k];
+                const sx = xScale(xValues[i]);
+                const sy = yScale(yValues[i]);
+                if (sx >= x0 && sx <= x1 && sy >= y0 && sy <= y1) {
+                    selected.add(rowIds[i]);
+                }
+            }
+        }
+    }
+    return selected;
+}
+
 export function getPointsInBrush(
     grid: DataPoint[][][],
     xScale: (v: number) => number,


### PR DESCRIPTION
First of a two-PR performance stack (the WebGL point renderer for #33 is stacked on this branch).

## What moved to typed arrays

New `src/utils/columnStore.ts` builds a derived, memoized columnar view of the dataset the matrix renders (the faceted array — the memo re-keys automatically when facets swap the array reference): one `Float64Array` per numeric column with **NaN for missing cells** (same semantics as `cellValueUtils`), a `rowIds: Int32Array` (store row *i* ↔ `data[i].__id`), and per-column `min`/`max`/`minPositive` computed in the same single build pass.

Hot paths in `ScatterPlotMatrix` now consume the store instead of row objects:

| Path | Before | After |
|---|---|---|
| Point paint loops (classic + color-by) | per point: property lookup ×2, `cellValueToNumber` ×2, `Set.has` | `Float64Array` reads + `Uint8Array` selection flag |
| Scale-domain stats | full row scan per render | free from the build pass (filter-mode selections do a flag-restricted rescan) |
| Brush spatial grid build/query | row-object grid | columnar grid of row indices |
| Histogram values + histogram-brush range scan | `rows.map(...).filter(isFinite)` / `+row[col]` scan | typed-array scans |

Row objects remain the source of truth for the table, tooltips, PCA, facets, stacked (color-by) histograms and the regression/correlation fits — no changes there.

## Measured numbers

Headless Chromium (SwiftShader, shared dev box), 30k rows × 8 cols = 56 cells ≈ 1.68M point-draws:

| Metric (median of 3) | main | this PR |
|---|---|---|
| Full-matrix repaint (zoom step) | 2 981 ms | 2 932 ms |
| Brush repaint (highlight mode) | 2 848 ms | 2 609 ms (−9%) |
| Isolated 30k-row traversal per cell (no canvas) | 1.31 ms | 0.25 ms (**5.3×**) |
| Isolated cell paint incl. canvas arcs | 5.06 ms | 3.07 ms (**1.65×**) |
| Per-column stats scan per render | 1.26 ms/col | ~0 (build-pass) |
| Store build (one-off per dataset) | — | 6.8 ms (30k×2); test gate: 30k×30 < 150 ms |

End-to-end wins are modest **because Canvas 2D rasterization (`arc`+`fill` per point) dominates** — exactly the cost the stacked WebGL PR removes. This PR is the prerequisite: the GPU renderer uploads these `Float64Array`s directly as vertex buffers.

Rendering is verified **pixel-identical** before/after (headless screenshots of the sample dataset and of a brushed 30k-row synthetic; `ImageChops.difference` = 0 pixels on both).

## Memory note

The store is additive: ~8 bytes × rows × columns (7.2 MB for 30k×30) on top of the row objects, which stay authoritative. The ~10× row-object overhead only goes away if/when row objects are dropped for numeric data — deliberately out of scope here.

## Behavior fix folded in

The histogram brush previously coerced cells with `+row[col]`, so missing cells (`null` → `0`) were silently selected whenever 0 was inside the brushed range. The columnar scan keeps NaN semantics — missing cells are never selected — matching the scatter brush and the spatial grid.

## Tests

15 new tests (`src/test/columnStore.test.ts`): build correctness/NaN semantics, rowIds mapping, build-pass stats vs legacy row scan, selection flags, flag-restricted stats, value extraction, columnar-vs-legacy spatial-grid parity, and perf gates (store build 30k×30 < 150 ms, flag rebuild < 20 ms, both × `CI_FACTOR`). Full suite: 300/300 green; `typecheck` and `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved scatter plot rendering, brushing, and histogram selection performance for large datasets.
  * Enhanced selection behavior with more consistent handling of missing or non-numeric coordinates and values.

* **Bug Fixes**
  * Fixed point highlighting/dimming/filter visibility to preserve prior visual states more accurately.
  * Prevented invalid values from affecting histogram/range selections and chart statistics.
  * Improved robustness against NaN/missing cells so results no longer drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->