### PR TITLE
perf: WebGL point-sprite renderer with Canvas 2D fallback (closes #33)

### DIFF
--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -16,6 +16,12 @@ import {
   collectFiniteValues,
   selectIdsInValueRange,
 } from '../src/utils/columnStore';
+import {
+  WebGLPointRenderer,
+  buildNormalizedPositions,
+  buildSlotAttribute,
+  paletteToRgba,
+} from '../src/utils/webglPoints';
 import { ImageDataLRU, totalSnapshotBytes } from '../src/utils/imageDataCache';
 import { cellValueToNumber } from '../src/utils/cellValueUtils';
 import { MISSING_COLOR, MISSING_SLOT } from '../src/utils/colorUtils';
@@ -364,6 +370,32 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     return brushSelection?.selectedIds || new Set<number>();
   }, [brushSelection]);
 
+  // Single data-identity version: bump whenever the data array reference
+  // changes (ref-guarded, so it is idempotent under strict-mode double
+  // renders). Two things depend on it: (1) distinct datasets can share
+  // length and __id range (__id is just the row index), so length/first/last
+  // alone cannot tell "file B, same shape" from "same file"; (2) value-only
+  // updates (e.g. recomputed PCA scores on the same rows/ids) reuse the same
+  // ids. Folding the version into dataStateHash means render keys — and the
+  // ImageData snapshots keyed by them — can never resurrect pixels from a
+  // previous dataset. Brush/selection changes reuse the same array, so
+  // canvas caching stays effective for interaction.
+  const dataVersionRef = useRef(0);
+  const lastDataRef = useRef<DataPoint[]>(data);
+  if (lastDataRef.current !== data) {
+    dataVersionRef.current += 1;
+    lastDataRef.current = data;
+  }
+
+  const dataStateHash = useMemo(() => {
+    if (data.length === 0) return `v${dataVersionRef.current}-empty`;
+    const firstId = data[0]?.__id ?? 0;
+    const lastId = data[data.length - 1]?.__id ?? 0;
+    return `v${dataVersionRef.current}-${data.length}-${firstId}-${lastId}`;
+  }, [data]);
+
+  const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds]);
+
   // Columnar typed-array store over the rendered dataset: one Float64Array
   // per column (NaN = missing) plus per-column min/max/minPositive from the
   // same single build pass. The hot paths below (point paint loops, scale
@@ -387,21 +419,103 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     [columnStore, selectedIds]
   );
 
+  // WebGL point backend (issue #33): one shared cell-sized context; each
+  // cell's points are drawn there and blitted into the cell's 2D canvas, so
+  // the snapshot LRU, reference-line overlay and PNG export pipelines run
+  // unchanged. `undefined` = not yet probed, `null` = unavailable/lost →
+  // the Canvas 2D loops below run exactly as before (jsdom, old browsers).
+  const glRendererRef = useRef<WebGLPointRenderer | null | undefined>(undefined);
+  useEffect(() => () => {
+    if (glRendererRef.current) glRendererRef.current.dispose();
+    glRendererRef.current = undefined;
+  }, []);
+
+  // Palette texture pixels for the active color state (slot colors + a
+  // trailing missing-color texel).
+  const glPalette = useMemo(
+    () => (colorState ? paletteToRgba(colorState.slotColors, MISSING_COLOR) : null),
+    [colorState]
+  );
+
   // Canvas rendering function: paints one cell's points from the columnar
   // store. Iterates store rows (== the matrix's dataset, faceting included);
   // filter-mode subsetting and highlight-mode dimming are driven by
   // selectedFlags, matching the previous row-object behavior exactly.
+  // When WebGL is available the points are drawn there instead and blitted
+  // in; the 2D loops below double as the fallback path.
   const renderPointsToCanvas = useCallback((
     canvas: HTMLCanvasElement,
     xValues: Float64Array,
     yValues: Float64Array,
     xScale: d3.ScaleLinear<number, number>,
-    yScale: d3.ScaleLinear<number, number>
+    yScale: d3.ScaleLinear<number, number>,
+    xColName: string,
+    yColName: string,
+    xLog: boolean,
+    yLog: boolean
   ) => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
     ctx.clearRect(0, 0, size, size);
+
+    // --- WebGL fast path -------------------------------------------------
+    if (glRendererRef.current === undefined) {
+      glRendererRef.current = WebGLPointRenderer.create(size);
+      console.info(
+        `[ScatterPlotMatrix] point rendering backend: ${glRendererRef.current ? 'WebGL' : 'Canvas 2D'}`
+      );
+    }
+    const glRenderer = glRendererRef.current;
+    if (glRenderer) {
+      try {
+        const xd = xScale.domain();
+        const yd = yScale.domain();
+        const xr = xScale.range();
+        const yr = yScale.range();
+        // Position buffers are normalized-t per (column, scale, domain), so
+        // the same buffer serves a column on either axis of any cell.
+        const xKey = `${dataStateHash}|${xColName}|${xLog ? 'log' : 'lin'}|${xd[0]}|${xd[1]}`;
+        const yKey = `${dataStateHash}|${yColName}|${yLog ? 'log' : 'lin'}|${yd[0]}|${yd[1]}`;
+        const ok = glRenderer.renderCell({
+          count: columnStore.length,
+          size,
+          xRange: [xr[0], xr[1]],
+          yRange: [yr[0], yr[1]],
+          x: { key: xKey, build: () => buildNormalizedPositions(xValues, xd[0], xd[1], xLog) },
+          y: { key: yKey, build: () => buildNormalizedPositions(yValues, yd[0], yd[1], yLog) },
+          flags: selectedFlags
+            ? { key: `${dataStateHash}|${selectedStateHash}`, data: selectedFlags }
+            : null,
+          color: colorState && glPalette
+            ? {
+              slots: {
+                key: `${dataStateHash}|slots|${colorState.hash}`,
+                build: () => buildSlotAttribute(
+                  colorState.slotById,
+                  columnStore.rowIds,
+                  colorState.slotColors.length
+                ),
+              },
+              paletteKey: colorState.hash,
+              palette: glPalette,
+              paletteSize: colorState.slotColors.length + 1,
+            }
+            : null,
+          filterMode,
+        });
+        if (ok) {
+          ctx.drawImage(glRenderer.canvas, 0, 0);
+          return;
+        }
+      } catch {
+        // Fall through to the 2D path below.
+      }
+      // Unusable context (lost / failed draw): permanent Canvas 2D fallback.
+      glRendererRef.current = null;
+      console.info('[ScatterPlotMatrix] WebGL context unusable — falling back to Canvas 2D');
+    }
+    // --- Canvas 2D path (also the WebGL fallback) ------------------------
 
     const rowCount = columnStore.length;
     const { rowIds } = columnStore;
@@ -495,7 +609,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     }
 
     ctx.globalAlpha = 1;
-  }, [size, colorState, columnStore, selectedFlags, filterMode]);
+  }, [size, colorState, columnStore, selectedFlags, filterMode, dataStateHash, selectedStateHash, glPalette]);
 
   // filteredData still feeds the row-object consumers (stacked histograms,
   // regression/correlation fits); the point/histogram hot paths read the
@@ -504,32 +618,6 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     () => filterData(data, selectedIds, filterMode),
     [data, selectedIds, filterMode]
   );
-
-  // Single data-identity version: bump whenever the data array reference
-  // changes (ref-guarded, so it is idempotent under strict-mode double
-  // renders). Two things depend on it: (1) distinct datasets can share
-  // length and __id range (__id is just the row index), so length/first/last
-  // alone cannot tell "file B, same shape" from "same file"; (2) value-only
-  // updates (e.g. recomputed PCA scores on the same rows/ids) reuse the same
-  // ids. Folding the version into dataStateHash means render keys — and the
-  // ImageData snapshots keyed by them — can never resurrect pixels from a
-  // previous dataset. Brush/selection changes reuse the same array, so
-  // canvas caching stays effective for interaction.
-  const dataVersionRef = useRef(0);
-  const lastDataRef = useRef<DataPoint[]>(data);
-  if (lastDataRef.current !== data) {
-    dataVersionRef.current += 1;
-    lastDataRef.current = data;
-  }
-
-  const dataStateHash = useMemo(() => {
-    if (data.length === 0) return `v${dataVersionRef.current}-empty`;
-    const firstId = data[0]?.__id ?? 0;
-    const lastId = data[data.length - 1]?.__id ?? 0;
-    return `v${dataVersionRef.current}-${data.length}-${firstId}-${lastId}`;
-  }, [data]);
-
-  const selectedStateHash = useMemo(() => computeSelectedStateHash(selectedIds), [selectedIds]);
 
   // Memoized per-cell pairwise stats (issues #50/#36): brush-driven repaints
   // in highlight mode reuse the same fit/correlation instead of re-scanning
@@ -1570,7 +1658,11 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           task.xValues,
           task.yValues,
           task.xScale,
-          task.yScale
+          task.yScale,
+          task.xColName,
+          task.yColName,
+          task.xLog,
+          task.yLog
         );
         // Reference-line overlay: a separate draw step after the point pass,
         // still inside the same task so snapshots capture the full cell.

--- a/src/test/webglPoints.test.ts
+++ b/src/test/webglPoints.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MISSING_T,
+  buildNormalizedPositions,
+  buildSlotAttribute,
+  paletteToRgba,
+  parseColor,
+  isWebGLAvailable,
+  WebGLPointRenderer,
+} from '../utils/webglPoints';
+import {
+  CATEGORY_PALETTE,
+  MISSING_SLOT,
+  MISSING_COLOR,
+  buildRainbowColors,
+} from '../utils/colorUtils';
+
+describe('buildNormalizedPositions', () => {
+  it('normalizes linear values against the domain like d3.scaleLinear', () => {
+    const values = new Float64Array([10, 15, 20]);
+    const t = buildNormalizedPositions(values, 10, 20, false);
+    expect(Array.from(t)).toEqual([0, 0.5, 1]);
+  });
+
+  it('maps NaN (missing) to the cull sentinel', () => {
+    const values = new Float64Array([10, NaN, 20]);
+    const t = buildNormalizedPositions(values, 10, 20, false);
+    expect(t[1]).toBe(MISSING_T);
+    expect(t[0]).toBe(0);
+    expect(t[2]).toBe(1);
+  });
+
+  it('normalizes log values like d3.scaleLog', () => {
+    const values = new Float64Array([1, 10, 100]);
+    const t = buildNormalizedPositions(values, 1, 100, true);
+    expect(t[0]).toBeCloseTo(0, 6);
+    expect(t[1]).toBeCloseTo(0.5, 6);
+    expect(t[2]).toBeCloseTo(1, 6);
+  });
+
+  it('culls non-positive values under a log scale (Canvas 2D dropped them via NaN coords)', () => {
+    const values = new Float64Array([0, -5, NaN, 10]);
+    const t = buildNormalizedPositions(values, 1, 100, true);
+    expect(t[0]).toBe(MISSING_T);
+    expect(t[1]).toBe(MISSING_T);
+    expect(t[2]).toBe(MISSING_T);
+    expect(t[3]).toBeGreaterThan(0);
+  });
+
+  it('centers points on a degenerate domain instead of dividing by zero', () => {
+    expect(buildNormalizedPositions(new Float64Array([5]), 5, 5, false)[0]).toBe(0.5);
+    expect(buildNormalizedPositions(new Float64Array([5]), 5, 5, true)[0]).toBe(0.5);
+  });
+});
+
+describe('buildSlotAttribute', () => {
+  it('maps __id slots through rowIds and buckets like the 2D paint loop', () => {
+    // Full dataset of 5 rows; store holds a faceted subset [row 3, row 0].
+    const slotById = new Uint16Array([2, 9, 1, 0, MISSING_SLOT]);
+    const rowIds = new Int32Array([3, 0, 4]);
+    const attr = buildSlotAttribute(slotById, rowIds, 10);
+    expect(Array.from(attr)).toEqual([0, 2, 10]); // MISSING_SLOT -> last texel
+  });
+
+  it('sends out-of-palette and out-of-bounds ids to the missing texel', () => {
+    const slotById = new Uint16Array([7]);
+    const rowIds = new Int32Array([0, 99]); // 99 is out of slotById bounds
+    const attr = buildSlotAttribute(slotById, rowIds, 4);
+    expect(Array.from(attr)).toEqual([4, 4]); // 7 >= numSlots, undefined -> 4
+  });
+});
+
+describe('paletteToRgba / parseColor', () => {
+  it('parses hex colors (the category palette)', () => {
+    expect(parseColor('#4e79a7')).toEqual([0x4e, 0x79, 0xa7]);
+    expect(parseColor('#ccc')).toEqual([0xcc, 0xcc, 0xcc]);
+  });
+
+  it('parses rgb()/rgba() strings (d3 interpolator output)', () => {
+    expect(parseColor('rgb(68, 1, 84)')).toEqual([68, 1, 84]);
+    expect(parseColor('rgba(68, 1, 84, 0.5)')).toEqual([68, 1, 84]);
+  });
+
+  it('builds RGBA texels for the real category palette + missing color', () => {
+    const rgba = paletteToRgba([...CATEGORY_PALETTE], MISSING_COLOR);
+    expect(rgba.length).toBe((CATEGORY_PALETTE.length + 1) * 4);
+    // First texel = first palette color
+    expect([rgba[0], rgba[1], rgba[2], rgba[3]]).toEqual([0x4e, 0x79, 0xa7, 255]);
+    // Last texel = missing color #9ca3af
+    const off = CATEGORY_PALETTE.length * 4;
+    expect([rgba[off], rgba[off + 1], rgba[off + 2]]).toEqual([0x9c, 0xa3, 0xaf]);
+  });
+
+  it('parses every real rainbow bucket color to a non-black texel', () => {
+    const rainbow = buildRainbowColors();
+    const rgba = paletteToRgba(rainbow, MISSING_COLOR);
+    expect(rgba.length).toBe((rainbow.length + 1) * 4);
+    let nonBlack = 0;
+    for (let i = 0; i < rainbow.length; i++) {
+      if (rgba[i * 4] + rgba[i * 4 + 1] + rgba[i * 4 + 2] > 0) nonBlack++;
+    }
+    expect(nonBlack).toBe(rainbow.length);
+  });
+});
+
+describe('WebGL fallback detection', () => {
+  it('reports WebGL as unavailable in jsdom (2D-mock contexts)', () => {
+    // jsdom's canvas mock returns a 2D-ish object for any context type; the
+    // method probe must reject it so the Canvas 2D path keeps running.
+    expect(isWebGLAvailable()).toBe(false);
+  });
+
+  it('WebGLPointRenderer.create returns null (never throws) without WebGL', () => {
+    expect(WebGLPointRenderer.create(150)).toBeNull();
+  });
+
+  it('accepts a real-looking WebGL context via the method probe', () => {
+    const fakeCanvas = {
+      getContext: (type: string) =>
+        type === 'webgl' ? { createShader: () => ({}) } : null,
+    } as unknown as HTMLCanvasElement;
+    expect(isWebGLAvailable(() => fakeCanvas)).toBe(true);
+  });
+});

--- a/src/utils/webglPoints.ts
+++ b/src/utils/webglPoints.ts
@@ -1,0 +1,545 @@
+/**
+ * Minimal hand-rolled WebGL1 point-sprite renderer for the scatter matrix
+ * (issue #33). No dependencies.
+ *
+ * Architecture — "render one cell, blit into its 2D canvas":
+ *
+ * - ONE shared WebGL context/canvas for the whole matrix (contexts are a
+ *   scarce resource), sized to a single cell. Each cell render draws the
+ *   points into it, and the caller `drawImage`s the result into the cell's
+ *   existing Canvas 2D element. That keeps the entire downstream pipeline —
+ *   reference-line overlays, the per-cell ImageData snapshot LRU, PNG
+ *   export, the fluid-zoom CSS transform and DOM z-order — working
+ *   verbatim, at the cost of one GPU→canvas blit per cell paint. (The
+ *   alternative, a matrix-sized WebGL layer under the 2D canvases, would
+ *   have required compositing changes in exportPng, a rethink of the
+ *   snapshot LRU, and scissor bookkeeping; with per-cell blitting a
+ *   matrix-sized canvas buys nothing, so the shared canvas is cell-sized.)
+ *
+ * - Positions are pre-transformed CPU-side into normalized [0, 1] "t"
+ *   values per (column × scale-type × domain) and cached as GPU buffers.
+ *   The vertex shader only lerps t into the cell's pixel range, so
+ *   linear/log is NOT a shader path: log10 happens once per column when the
+ *   domain or scale actually changes, not per point per frame. This also
+ *   gives robust missing-value handling — NaN (and non-positive values
+ *   under a log scale, which Canvas 2D silently dropped via NaN coords)
+ *   become a sentinel t that the shader pushes outside the clip volume, so
+ *   the point is culled. GLSL ES 1.0 has no isnan(), so the sentinel
+ *   approach beats uploading raw values.
+ *
+ * - Per-point color comes from a small palette texture (≤ 65 texels: 10
+ *   category colors or 64 rainbow buckets, + 1 missing-color texel) indexed
+ *   by a per-point slot attribute derived from ColorState.slotById
+ *   (Uint16 → Float32 attribute, same bucket rules as the 2D path).
+ *
+ * - Selection dimming uses a per-point flag attribute (the Uint8Array of
+ *   selection flags already built per selection change for the columnar
+ *   store). Two draw passes keep the 2D path's z-order: unselected
+ *   (dimmed gray) beneath, selected on top; filter mode skips the first
+ *   pass entirely.
+ *
+ * - Premultiplied-alpha blending (ONE, ONE_MINUS_SRC_ALPHA into a
+ *   transparent buffer) so the blit composites exactly like source-over.
+ *   Round points via gl_PointCoord distance with a 1px smoothstep edge to
+ *   approximate Canvas 2D's antialiased arcs.
+ */
+
+/** Sentinel t for missing values; the vertex shader culls anything ≤ -9. */
+export const MISSING_T = -10;
+
+/** Point radius in px — matches the Canvas 2D `arc(x, y, 2.5, …)` path. */
+export const POINT_RADIUS = 2.5;
+// Sprite quad size: diameter + 1px of antialiasing margin on each side.
+const POINT_SPRITE_SIZE = POINT_RADIUS * 2 + 1;
+
+// Cap on cached position/slot GPU buffers. Each is 4 bytes × rows; at 1M
+// rows a full cache is ~24 × 4MB = 96MB GPU memory worst-case.
+const BUFFER_CACHE_CAPACITY = 24;
+
+const VERTEX_SHADER = `
+attribute float aX;
+attribute float aY;
+attribute float aSlot;
+attribute float aFlag;
+uniform vec2 uXRange;      // pixel range for t=0..1 (pad/2 .. size-pad/2)
+uniform vec2 uYRange;      // pixel range, y-down like canvas
+uniform float uCanvasSize;
+// mediump to match the fragment shader's default precision — a highp/mediump
+// mismatch on a shared uniform is a LINK ERROR on some drivers (SwiftShader).
+uniform mediump float uPointSize;
+varying float vSlot;
+varying float vFlag;
+void main() {
+  vSlot = aSlot;
+  vFlag = aFlag;
+  gl_PointSize = uPointSize;
+  if (aX <= -9.0 || aY <= -9.0) {
+    // Missing value: outside the clip volume -> the point is culled.
+    gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
+    return;
+  }
+  float px = mix(uXRange.x, uXRange.y, aX);
+  float py = mix(uYRange.x, uYRange.y, aY);
+  vec2 ndc = vec2(px, uCanvasSize - py) / uCanvasSize * 2.0 - 1.0;
+  gl_Position = vec4(ndc, 0.0, 1.0);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision mediump float;
+varying float vSlot;
+varying float vFlag;
+uniform float uPass;        // 0: unselected only, 1: selected only, 2: all
+uniform float uUseTexture;  // 1: palette texture by vSlot, 0: uColor.rgb
+uniform vec4 uColor;        // straight (non-premultiplied) rgba
+uniform sampler2D uPalette;
+uniform float uPaletteSize;
+uniform float uPointRadius;
+uniform float uPointSize;
+void main() {
+  if (uPass < 0.5 && vFlag > 0.5) discard;
+  if (uPass > 0.5 && uPass < 1.5 && vFlag < 0.5) discard;
+  vec2 c = (gl_PointCoord - 0.5) * uPointSize;
+  float dist = length(c);
+  float mask = 1.0 - smoothstep(uPointRadius - 1.0, uPointRadius, dist);
+  if (mask <= 0.004) discard;
+  vec3 rgb = uColor.rgb;
+  if (uUseTexture > 0.5) {
+    rgb = texture2D(uPalette, vec2((vSlot + 0.5) / uPaletteSize, 0.5)).rgb;
+  }
+  float alpha = uColor.a * mask;
+  gl_FragColor = vec4(rgb * alpha, alpha);
+}
+`;
+
+// ---------------------------------------------------------------------------
+// CPU-side helpers (shader-independent; unit-tested without a GL context)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a column's values into [0, 1] against a domain, matching what
+ * d3.scaleLinear / d3.scaleLog do before their range lerp. NaN — and, under
+ * log, non-positive values (Canvas 2D dropped those via NaN screen coords) —
+ * become MISSING_T so the shader culls them.
+ */
+export function buildNormalizedPositions(
+  values: Float64Array,
+  domainMin: number,
+  domainMax: number,
+  log: boolean
+): Float32Array {
+  const out = new Float32Array(values.length);
+  if (log) {
+    const logMin = Math.log10(domainMin);
+    const span = Math.log10(domainMax) - logMin;
+    for (let i = 0; i < values.length; i++) {
+      const v = values[i];
+      if (!(v > 0)) { // NaN and v <= 0
+        out[i] = MISSING_T;
+      } else {
+        out[i] = span === 0 ? 0.5 : (Math.log10(v) - logMin) / span;
+      }
+    }
+    return out;
+  }
+  const span = domainMax - domainMin;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v !== v) {
+      out[i] = MISSING_T;
+    } else {
+      out[i] = span === 0 ? 0.5 : (v - domainMin) / span;
+    }
+  }
+  return out;
+}
+
+/**
+ * Per-point palette slot attribute from ColorState.slotById (indexed by
+ * __id) via the store's rowIds. Bucket rules mirror the 2D paint loop:
+ * MISSING_SLOT, out-of-palette and out-of-bounds ids all land in the last
+ * texel (the missing color).
+ */
+export function buildSlotAttribute(
+  slotById: Uint16Array,
+  rowIds: Int32Array,
+  numSlots: number
+): Float32Array {
+  const out = new Float32Array(rowIds.length);
+  for (let i = 0; i < rowIds.length; i++) {
+    const slot = slotById[rowIds[i]]; // undefined when __id out of bounds
+    out[i] = slot === undefined || slot >= numSlots ? numSlots : slot;
+  }
+  return out;
+}
+
+/**
+ * Palette texture pixels: one RGBA texel per slot color plus a final texel
+ * for the missing color. Accepts #rgb/#rrggbb and rgb()/rgba() strings
+ * (d3 interpolators return the latter).
+ */
+export function paletteToRgba(slotColors: string[], missingColor: string): Uint8Array {
+  const colors = [...slotColors, missingColor];
+  const out = new Uint8Array(colors.length * 4);
+  for (let i = 0; i < colors.length; i++) {
+    const [r, g, b] = parseColor(colors[i]);
+    out[i * 4] = r;
+    out[i * 4 + 1] = g;
+    out[i * 4 + 2] = b;
+    out[i * 4 + 3] = 255;
+  }
+  return out;
+}
+
+/** Parse '#rgb', '#rrggbb', 'rgb(r, g, b)' or 'rgba(r, g, b, a)' to [r, g, b]. */
+export function parseColor(color: string): [number, number, number] {
+  const c = color.trim();
+  if (c.startsWith('#')) {
+    const hex = c.slice(1);
+    if (hex.length === 3) {
+      return [
+        parseInt(hex[0] + hex[0], 16),
+        parseInt(hex[1] + hex[1], 16),
+        parseInt(hex[2] + hex[2], 16),
+      ];
+    }
+    return [
+      parseInt(hex.slice(0, 2), 16),
+      parseInt(hex.slice(2, 4), 16),
+      parseInt(hex.slice(4, 6), 16),
+    ];
+  }
+  const m = c.match(/rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/);
+  if (m) return [Math.round(+m[1]), Math.round(+m[2]), Math.round(+m[3])];
+  return [0, 0, 0];
+}
+
+/**
+ * Feature detection. Returns false where WebGL1 is unavailable — including
+ * jsdom, whose canvas mock returns a context-like object for any type
+ * string, hence the method probe rather than a simple truthiness check.
+ */
+export function isWebGLAvailable(
+  createCanvas: () => HTMLCanvasElement = () => document.createElement('canvas')
+): boolean {
+  try {
+    const canvas = createCanvas();
+    const gl =
+      canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl');
+    return !!gl && typeof (gl as WebGLRenderingContext).createShader === 'function';
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+export interface BufferSource {
+  /** Cache key; MUST change whenever the produced data would change. */
+  key: string;
+  /** Called only on cache miss. */
+  build: () => Float32Array;
+}
+
+export interface CellRenderOptions {
+  /** Number of points (rows) in the buffers. */
+  count: number;
+  /** Cell edge in px; the shared canvas is resized on change. */
+  size: number;
+  /** Pixel range for t=0..1 on x (padding/2 .. size - padding/2). */
+  xRange: [number, number];
+  /** Pixel range for t=0..1 on y (size - padding/2 .. padding/2). */
+  yRange: [number, number];
+  x: BufferSource;
+  y: BufferSource;
+  /** Per-point selection flags (1 = selected); null when nothing selected. */
+  flags: { key: string; data: Uint8Array } | null;
+  /** Per-point palette coloring; null for the classic flat colors. */
+  color: {
+    slots: BufferSource;
+    /** RGBA texels incl. trailing missing-color texel (paletteToRgba). */
+    paletteKey: string;
+    palette: Uint8Array;
+    /** Texel count == palette.length / 4. */
+    paletteSize: number;
+  } | null;
+  filterMode: 'highlight' | 'filter';
+}
+
+interface CachedBuffer {
+  buffer: WebGLBuffer;
+  lastUse: number;
+}
+
+/**
+ * The shared point renderer. Create via WebGLPointRenderer.create(); a null
+ * result means no usable WebGL — callers keep the Canvas 2D path.
+ */
+export class WebGLPointRenderer {
+  readonly canvas: HTMLCanvasElement;
+  private gl: WebGLRenderingContext;
+  private program: WebGLProgram;
+  private attribs: { aX: number; aY: number; aSlot: number; aFlag: number };
+  private uniforms: Record<string, WebGLUniformLocation | null>;
+  private positionBuffers = new Map<string, CachedBuffer>();
+  private useTick = 0;
+  private flagBuffer: WebGLBuffer | null = null;
+  private flagKey = '';
+  private paletteTexture: WebGLTexture | null = null;
+  private paletteKey = '';
+  private contextLost = false;
+  private size = 0;
+
+  static create(size: number): WebGLPointRenderer | null {
+    try {
+      const canvas = document.createElement('canvas');
+      const attrs: WebGLContextAttributes = {
+        alpha: true,
+        premultipliedAlpha: true,
+        // The caller drawImage-blits right after the draw calls; preserve
+        // the buffer so the blit can never race the compositor's clear.
+        preserveDrawingBuffer: true,
+        antialias: false,
+        depth: false,
+        stencil: false,
+      };
+      const gl = (canvas.getContext('webgl', attrs) ??
+        canvas.getContext('experimental-webgl', attrs)) as WebGLRenderingContext | null;
+      if (!gl || typeof gl.createShader !== 'function') return null;
+      return new WebGLPointRenderer(canvas, gl, size);
+    } catch (err) {
+      console.info('[webglPoints] create failed:', err);
+      return null;
+    }
+  }
+
+  private constructor(canvas: HTMLCanvasElement, gl: WebGLRenderingContext, size: number) {
+    this.canvas = canvas;
+    this.gl = gl;
+
+    canvas.addEventListener('webglcontextlost', event => {
+      event.preventDefault();
+      this.contextLost = true;
+    });
+
+    const program = gl.createProgram();
+    if (!program) throw new Error('createProgram failed');
+    gl.attachShader(program, compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER));
+    gl.attachShader(program, compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER));
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      throw new Error(`program link failed: ${gl.getProgramInfoLog(program)}`);
+    }
+    this.program = program;
+    gl.useProgram(program);
+
+    this.attribs = {
+      aX: gl.getAttribLocation(program, 'aX'),
+      aY: gl.getAttribLocation(program, 'aY'),
+      aSlot: gl.getAttribLocation(program, 'aSlot'),
+      aFlag: gl.getAttribLocation(program, 'aFlag'),
+    };
+    this.uniforms = Object.fromEntries(
+      [
+        'uXRange', 'uYRange', 'uCanvasSize', 'uPointSize', 'uPass',
+        'uUseTexture', 'uColor', 'uPalette', 'uPaletteSize', 'uPointRadius',
+      ].map(name => [name, gl.getUniformLocation(program, name)])
+    );
+
+    gl.disable(gl.DEPTH_TEST);
+    gl.enable(gl.BLEND);
+    // Premultiplied-alpha source-over, matching Canvas 2D compositing.
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    gl.uniform1f(this.uniforms.uPointSize, POINT_SPRITE_SIZE);
+    gl.uniform1f(this.uniforms.uPointRadius, POINT_RADIUS);
+
+    this.setSize(size);
+  }
+
+  get isContextLost(): boolean {
+    return this.contextLost || this.gl.isContextLost();
+  }
+
+  setSize(size: number): void {
+    if (this.size === size) return;
+    this.size = size;
+    this.canvas.width = size;
+    this.canvas.height = size;
+    this.gl.viewport(0, 0, size, size);
+    this.gl.uniform1f(this.uniforms.uCanvasSize, size);
+  }
+
+  /**
+   * Draw one cell's points into the shared canvas. Returns false when the
+   * context is unusable (caller should fall back to Canvas 2D).
+   */
+  renderCell(opts: CellRenderOptions): boolean {
+    if (this.isContextLost) return false;
+    const { gl } = this;
+    this.setSize(opts.size);
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    if (opts.count === 0) return true;
+
+    gl.uniform2f(this.uniforms.uXRange, opts.xRange[0], opts.xRange[1]);
+    gl.uniform2f(this.uniforms.uYRange, opts.yRange[0], opts.yRange[1]);
+
+    this.bindPositionAttribute(this.attribs.aX, opts.x);
+    this.bindPositionAttribute(this.attribs.aY, opts.y);
+
+    // Selection flags: shared buffer, re-uploaded only when the key changes.
+    if (opts.flags) {
+      if (!this.flagBuffer) this.flagBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.flagBuffer);
+      if (this.flagKey !== opts.flags.key) {
+        gl.bufferData(gl.ARRAY_BUFFER, opts.flags.data, gl.STATIC_DRAW);
+        this.flagKey = opts.flags.key;
+      }
+      gl.enableVertexAttribArray(this.attribs.aFlag);
+      gl.vertexAttribPointer(this.attribs.aFlag, 1, gl.UNSIGNED_BYTE, false, 0, 0);
+    } else {
+      gl.disableVertexAttribArray(this.attribs.aFlag);
+      gl.vertexAttrib1f(this.attribs.aFlag, 0);
+    }
+
+    // Palette coloring: slot attribute + palette texture.
+    if (opts.color) {
+      this.bindPositionAttribute(this.attribs.aSlot, opts.color.slots);
+      this.uploadPalette(opts.color.paletteKey, opts.color.palette, opts.color.paletteSize);
+      gl.uniform1f(this.uniforms.uPaletteSize, opts.color.paletteSize);
+    } else {
+      gl.disableVertexAttribArray(this.attribs.aSlot);
+      gl.vertexAttrib1f(this.attribs.aSlot, 0);
+    }
+
+    const hasSelection = opts.flags !== null;
+    if (!hasSelection) {
+      // Single pass over every point.
+      if (opts.color) {
+        this.draw(2, true, [0, 0, 0, 0.7], opts.count);
+      } else {
+        this.draw(2, false, colorToVec4('#4b5563', 0.7), opts.count);
+      }
+      return true;
+    }
+
+    // Selection z-order matches the 2D path: dimmed unselected beneath
+    // (highlight mode only), selected on top.
+    if (opts.filterMode === 'highlight') {
+      this.draw(0, false, colorToVec4('#ccc', 0.3), opts.count);
+    }
+    if (opts.color) {
+      this.draw(1, true, [0, 0, 0, 0.8], opts.count);
+    } else {
+      this.draw(1, false, colorToVec4('#1e40af', 0.8), opts.count);
+    }
+    return true;
+  }
+
+  dispose(): void {
+    const { gl } = this;
+    this.positionBuffers.forEach(({ buffer }) => gl.deleteBuffer(buffer));
+    this.positionBuffers.clear();
+    if (this.flagBuffer) gl.deleteBuffer(this.flagBuffer);
+    if (this.paletteTexture) gl.deleteTexture(this.paletteTexture);
+    gl.deleteProgram(this.program);
+    const lose = gl.getExtension('WEBGL_lose_context');
+    lose?.loseContext();
+  }
+
+  /** Cached position/slot buffer keys, oldest first (for tests). */
+  cachedBufferKeys(): string[] {
+    return Array.from(this.positionBuffers.keys());
+  }
+
+  private draw(
+    pass: number,
+    useTexture: boolean,
+    rgba: [number, number, number, number],
+    count: number
+  ): void {
+    const { gl } = this;
+    gl.uniform1f(this.uniforms.uPass, pass);
+    gl.uniform1f(this.uniforms.uUseTexture, useTexture ? 1 : 0);
+    gl.uniform4f(this.uniforms.uColor, rgba[0], rgba[1], rgba[2], rgba[3]);
+    gl.drawArrays(gl.POINTS, 0, count);
+  }
+
+  private bindPositionAttribute(location: number, source: BufferSource): void {
+    const { gl } = this;
+    let cached = this.positionBuffers.get(source.key);
+    if (!cached) {
+      const buffer = gl.createBuffer();
+      if (!buffer) return;
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(gl.ARRAY_BUFFER, source.build(), gl.STATIC_DRAW);
+      cached = { buffer, lastUse: 0 };
+      this.positionBuffers.set(source.key, cached);
+      this.evictStaleBuffers();
+    } else {
+      gl.bindBuffer(gl.ARRAY_BUFFER, cached.buffer);
+    }
+    cached.lastUse = ++this.useTick;
+    gl.enableVertexAttribArray(location);
+    gl.vertexAttribPointer(location, 1, gl.FLOAT, false, 0, 0);
+  }
+
+  private evictStaleBuffers(): void {
+    while (this.positionBuffers.size > BUFFER_CACHE_CAPACITY) {
+      let oldestKey: string | null = null;
+      let oldestUse = Infinity;
+      this.positionBuffers.forEach((entry, key) => {
+        if (entry.lastUse < oldestUse) {
+          oldestUse = entry.lastUse;
+          oldestKey = key;
+        }
+      });
+      if (oldestKey === null) return;
+      const evicted = this.positionBuffers.get(oldestKey)!;
+      this.gl.deleteBuffer(evicted.buffer);
+      this.positionBuffers.delete(oldestKey);
+    }
+  }
+
+  private uploadPalette(key: string, palette: Uint8Array, texels: number): void {
+    const { gl } = this;
+    if (!this.paletteTexture) this.paletteTexture = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, this.paletteTexture);
+    if (this.paletteKey !== key) {
+      gl.texImage2D(
+        gl.TEXTURE_2D, 0, gl.RGBA, texels, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, palette
+      );
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      this.paletteKey = key;
+    }
+    gl.uniform1i(this.uniforms.uPalette, 0);
+  }
+}
+
+function compileShader(
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string
+): WebGLShader {
+  const shader = gl.createShader(type);
+  if (!shader) throw new Error('createShader failed');
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    throw new Error(`shader compile failed: ${gl.getShaderInfoLog(shader)}`);
+  }
+  return shader;
+}
+
+function colorToVec4(color: string, alpha: number): [number, number, number, number] {
+  const [r, g, b] = parseColor(color);
+  return [r / 255, g / 255, b / 255, alpha];
+}

--- a/src/utils/webglPoints.ts
+++ b/src/utils/webglPoints.ts
@@ -326,9 +326,15 @@ export class WebGLPointRenderer {
 
     const program = gl.createProgram();
     if (!program) throw new Error('createProgram failed');
-    gl.attachShader(program, compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER));
-    gl.attachShader(program, compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER));
+    const vs = compileShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+    const fs = compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
     gl.linkProgram(program);
+    // Flag shaders for deletion now that the program holds them; otherwise
+    // they outlive deleteProgram() and leak across dispose/recreate cycles.
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
       throw new Error(`program link failed: ${gl.getProgramInfoLog(program)}`);
     }
@@ -477,13 +483,16 @@ export class WebGLPointRenderer {
       if (!buffer) return;
       gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
       gl.bufferData(gl.ARRAY_BUFFER, source.build(), gl.STATIC_DRAW);
-      cached = { buffer, lastUse: 0 };
+      // Stamp before evicting: with lastUse 0 a full cache would evict the
+      // buffer just uploaded (it has the minimum tick), deleting it out from
+      // under the draw call below and forcing a rebuild on every frame.
+      cached = { buffer, lastUse: ++this.useTick };
       this.positionBuffers.set(source.key, cached);
       this.evictStaleBuffers();
     } else {
       gl.bindBuffer(gl.ARRAY_BUFFER, cached.buffer);
+      cached.lastUse = ++this.useTick;
     }
-    cached.lastUse = ++this.useTick;
     gl.enableVertexAttribArray(location);
     gl.vertexAttribPointer(location, 1, gl.FLOAT, false, 0, 0);
   }


### PR DESCRIPTION
**Stacked PR** — based on #73 (columnar typed-array store); merge that first. Closes #33.

## What this adds

`src/utils/webglPoints.ts`: a minimal hand-rolled WebGL1 point-sprite renderer — no dependency — that takes over ONLY the per-cell point painting. Axes/labels/histograms stay SVG; reference lines, correlation badges/tints, brush overlays and everything else are untouched.

## Integration choice: render per cell, blit into the existing 2D canvas

Two options were evaluated:

1. **Direct layer**: a matrix-sized WebGL canvas under the 2D canvases (scissor/viewport per cell). Saves the blit, but `exportPng` would need the GL layer composited in, the per-cell ImageData snapshot LRU semantics would need a rethink (snapshots would no longer contain points), and z-order/transparent-hole management touches every overlay.
2. **Blit-into-2D** (chosen): ONE shared WebGL context, canvas sized to a single cell; each cell's points are drawn there and `drawImage`-blitted into the cell's existing 2D canvas inside the same paint task. The entire downstream pipeline — reference-line overlay pass, ImageData snapshot LRU (`getImageData` on the 2D canvas now captures the blitted points), PNG export, fluid-zoom CSS transform, DOM z-order — works **verbatim**, at the cost of one blit per cell paint.

Correctness of existing features outranks peak FPS, so (2) wins. With per-cell blitting a matrix-sized GL canvas buys nothing, so the shared canvas is cell-sized — still exactly one context for the whole matrix.

## Renderer design

- **Positions**: pre-transformed CPU-side into normalized `[0,1]` t-values per (column × scale × domain) straight from the columnar store's `Float64Array`s, cached as GPU buffers (LRU-capped at 24; one buffer serves a column on either axis of any cell). The vertex shader just lerps t into the cell's pixel range — log/linear is a once-per-domain-change O(n) CPU transform, not per-point shader work. Chosen over raw-value upload + shader log because GLSL ES 1.0 has no `isnan()`: NaN (and non-positive values under log, which Canvas 2D silently dropped via NaN coords) become a sentinel t the shader culls.
- **Color-by**: per-point slot attribute (Uint16 `ColorState.slotById` → Float32 via the store's `rowIds`, same bucket rules as the 2D loop incl. the missing bucket) + a ≤65-texel palette texture (10 category colors / 64 rainbow buckets + missing color).
- **Selection dimming**: the store's per-row `Uint8Array` selection flags (rebuilt per selection change in the stacked PR) upload directly as a per-point attribute; two draw passes preserve the 2D z-order (dimmed gray unselected beneath, colored/blue selected on top; filter mode skips pass 1).
- **Look**: round sprites via `gl_PointCoord` distance + 1px smoothstep edge; premultiplied-alpha blending (`ONE, ONE_MINUS_SRC_ALPHA`) so the blit composites exactly like canvas source-over.

## Fallback

Feature detection uses a method probe (`typeof gl.createShader === 'function'`) because jsdom's canvas mock hands back a 2D-ish object for *any* context type. No WebGL (jsdom, old browsers) or a lost/unusable context ⇒ the existing Canvas 2D loops run unchanged, permanently for the session. The active backend is logged once: `[ScatterPlotMatrix] point rendering backend: WebGL | Canvas 2D`.

## Benchmarks (headless Chromium, SwiftShader — software GL)

Full-matrix paint / brush-repaint, median of 3, same build with GL force-disabled for the 2D column ("full paint" = enabling all columns; brush in highlight mode):

| Scale | Cells × points | Canvas 2D full | WebGL full | Canvas 2D brush | WebGL brush |
|---|---|---|---|---|---|
| 30k × 8 cols | 56 × 30k (1.7M) | 2.9 s | 0.3–1.1 s | 2.6 s | 1.6 s |
| 200k × 8 cols | 56 × 200k (11.2M) | 15.4 s | 4.5 s | 15.5 s | 8.8 s |
| 1M × 4 cols | 12 × 1M (12M) | 15.5 s | 4.2 s | 15.7 s | 8.8 s |

**Honesty notes**: these run on SwiftShader, i.e. the "GPU" is still the CPU — a real GPU makes vertex/fragment work ~free, so expect far larger wins there; what remains is CPU-side work this PR doesn't move (brush spatial-grid build, selection-flag rebuild, per-cell blits + snapshot `getImageData`, and the RAF scheduler's 4-cells-per-frame pacing, which alone floors a 56-cell paint at ~230 ms). Brush repaints are ~2× the no-selection paint because of the two-pass draw. Per the ROADMAP, 1M+ points are GPU-side interactive; the matrix-wide numbers above are the *full 12M-instance* repaint on software GL.

Visual verification: A/B against the Canvas 2D backend on the same build across plain / brush-highlight / brush-filter / rainbow / rainbow+brush / category / category+log / log flows — only antialiasing-level differences (≤2% of pixels, mean channel diff < 1/255). PNG export verified to contain the points (the blit keeps the 2D canvases authoritative). Known cosmetic deltas: GL point edges are smoothstep-antialiased rather than canvas-AA, and same-color overlapping points composite in row order rather than canvas's per-color batch order.

## Tests

14 new tests (`src/test/webglPoints.test.ts`) for the shader-independent logic: position normalization (linear/log/NaN/non-positive/degenerate domains), slot-attribute bucketing (missing slot, out-of-palette, out-of-bounds ids), palette texel building against the real category palette and viridis ramp, and fallback detection (jsdom mock rejected, real-looking context accepted, `create()` never throws). Full suite 314/314 green; `typecheck` and `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PauMsS57sT6ciaR1ChZs9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scatter plot matrices now render points faster in supported browsers using WebGL, with the same visual output and existing canvas fallback.

* **Bug Fixes**
  * Improved handling of selections, color updates, and axis scaling so plots refresh more reliably.
  * Added better support for missing values and edge cases, including log-scaled axes and empty/degenerate ranges.
  * WebGL rendering now safely falls back when unavailable or if context creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->