### PR TITLE
Category legend: counts, size-ranked z-order, click-to-hide

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: verify
+description: Build, launch and drive this app to verify a change end-to-end in a real browser.
+---
+
+# Verifying Demonstrable-Plotalizer changes
+
+Vite + React SPA; the surface is the browser at http://localhost:3000.
+
+## Launch
+
+```bash
+npm install        # only if node_modules is missing
+npm run dev        # background; serves on port 3000
+```
+
+## Load a dataset
+
+- Default load is `public/data/sample.csv` (iris — 150 rows, 3 species of 50 each; useless for count-skewed features).
+- To drive a custom CSV: drop it in `public/data/<name>.csv` (served same-origin by Vite) and navigate to
+  `http://localhost:3000/?data=http://localhost:3000/data/<name>.csv`. Delete the file when done — public/ is checked in.
+
+## Driving tips
+
+- Rendering backend is logged to the console: `[ScatterPlotMatrix] point rendering backend: WebGL|Canvas 2D`.
+  Real Chrome uses WebGL; jsdom tests only ever exercise the Canvas 2D path, so browser verification is the only
+  coverage the WebGL path gets.
+- Sidebar sections (Color, Facets, Analysis…) are collapsible; native `<select>`s respond well to form_input.
+- Brush-select by click-dragging inside a scatter cell; the selected-rows table appears at the bottom with a row
+  count — good for asserting selection semantics. Escape clears the selection.
+- Legend/category clicks: prefer element refs over coordinates; rows are small and easy to miss.

--- a/App.tsx
+++ b/App.tsx
@@ -70,6 +70,9 @@ const App: React.FC = () => {
   const [colorMode, setColorMode] = useState<ColorMode>('none');
   const [categoryColorColumn, setCategoryColorColumn] = useState<string | null>(null);
   const [rainbowOrderColumn, setRainbowOrderColumn] = useState<string | null>(null);
+  // Categories toggled off via the legend (category color mode only).
+  // Scoped to the active category column — switching columns resets it.
+  const [hiddenCategories, setHiddenCategories] = useState<ReadonlySet<string>>(new Set());
   // Issue #41: per category column, the set of selected facet values.
   // Absent column = no facet (all rows pass).
   const [facetSelections, setFacetSelections] = useState<FacetSelections>(new Map());
@@ -179,6 +182,7 @@ const App: React.FC = () => {
     // Color-by columns are dataset-specific; the mode itself is kept so e.g.
     // rainbow-by-file-order survives loading a new file.
     setCategoryColorColumn(prev => (prev && allStringCols.includes(prev) ? prev : null));
+    setHiddenCategories(new Set()); // category values are dataset-specific
     // No string columns means category mode can't apply at all; drop back to
     // 'none' so the UI doesn't show a disabled "Category" option as selected.
     // (If other string columns exist, the mode is kept and the sub-select
@@ -471,9 +475,38 @@ const App: React.FC = () => {
   // keeps category colors and rainbow ranks stable while faceting — points
   // keep their color instead of reshuffling as rows are hidden.
   const colorState = useMemo(
-    () => computeColorState(data, colorMode, categoryColorColumn, rainbowOrderColumn),
-    [data, colorMode, categoryColorColumn, rainbowOrderColumn]
+    () => computeColorState(data, colorMode, categoryColorColumn, rainbowOrderColumn, hiddenCategories),
+    [data, colorMode, categoryColorColumn, rainbowOrderColumn, hiddenCategories]
   );
+
+  // Hidden-category state is only meaningful for the column it was toggled
+  // against; switching columns starts fresh with everything visible.
+  const handleSetCategoryColorColumn = useCallback((column: string | null) => {
+    setCategoryColorColumn(column);
+    setHiddenCategories(new Set());
+  }, []);
+
+  // Legend click: toggle a category off/on. When hiding, its rows are also
+  // dropped from any live brush selection so the data table and selection
+  // count can't include invisible points. (Re-showing does not re-add them —
+  // re-brush to pick them up again.)
+  const handleToggleCategory = useCallback((name: string) => {
+    const hiding = !hiddenCategories.has(name);
+    const next = new Set(hiddenCategories);
+    if (hiding) next.add(name); else next.delete(name);
+    setHiddenCategories(next);
+
+    if (hiding && categoryColorColumn && brushSelection?.selectedIds?.size) {
+      const remaining = new Set<number>();
+      for (const row of data) {
+        if (!brushSelection.selectedIds.has(row.__id)) continue;
+        if (String(row[categoryColorColumn] ?? '') !== name) remaining.add(row.__id);
+      }
+      if (remaining.size !== brushSelection.selectedIds.size) {
+        setBrushSelection(remaining.size === 0 ? null : { ...brushSelection, selectedIds: remaining });
+      }
+    }
+  }, [hiddenCategories, categoryColorColumn, brushSelection, data]);
 
   // Issue #36: sort columns by mean absolute correlation against the other
   // visible columns (descending). Visibility comes from displayColumns —
@@ -733,7 +766,8 @@ const App: React.FC = () => {
               colorMode={colorMode}
               setColorMode={setColorMode}
               categoryColorColumn={categoryColorColumn}
-              setCategoryColorColumn={setCategoryColorColumn}
+              setCategoryColorColumn={handleSetCategoryColorColumn}
+              onToggleCategory={handleToggleCategory}
               rainbowOrderColumn={rainbowOrderColumn}
               onResetRainbowOrder={() => setRainbowOrderColumn(null)}
               colorState={colorState}

--- a/App.tsx
+++ b/App.tsx
@@ -497,10 +497,12 @@ const App: React.FC = () => {
     setHiddenCategories(next);
 
     if (hiding && categoryColorColumn && brushSelection?.selectedIds?.size) {
+      // O(selection) not O(data): __id is the row's position in `data`
+      // (assigned at load and never reordered), so ids index directly.
       const remaining = new Set<number>();
-      for (const row of data) {
-        if (!brushSelection.selectedIds.has(row.__id)) continue;
-        if (String(row[categoryColorColumn] ?? '') !== name) remaining.add(row.__id);
+      for (const id of brushSelection.selectedIds) {
+        const row = data[id];
+        if (row && String(row[categoryColorColumn] ?? '') !== name) remaining.add(id);
       }
       if (remaining.size !== brushSelection.selectedIds.size) {
         setBrushSelection(remaining.size === 0 ? null : { ...brushSelection, selectedIds: remaining });

--- a/components/ControlPanel.tsx
+++ b/components/ControlPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { Column, FilterMode, ColorMode } from '../types';
 import type { CorrelationKind } from '../src/utils/correlationUtils';
+import { CATEGORY_PALETTE } from '../src/utils/colorUtils';
 import type { ColorState } from '../src/utils/colorUtils';
 import type { FacetColumnSummary, FacetSelections } from '../src/utils/facetUtils';
 import { FileUpload } from './FileUpload';
@@ -64,6 +65,7 @@ interface ControlPanelProps {
   setColorMode: (mode: ColorMode) => void;
   categoryColorColumn: string | null;
   setCategoryColorColumn: (column: string | null) => void;
+  onToggleCategory: (name: string) => void;
   rainbowOrderColumn: string | null;
   onResetRainbowOrder: () => void;
   colorState: ColorState | null;
@@ -123,6 +125,7 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
   setColorMode,
   categoryColorColumn,
   setCategoryColorColumn,
+  onToggleCategory,
   rainbowOrderColumn,
   onResetRainbowOrder,
   colorState,
@@ -531,22 +534,42 @@ export const ControlPanel: React.FC<ControlPanelProps> = ({
                 ))}
               </select>
               {colorState?.categories && colorState.categories.length > 0 && (
-                <div className="mt-2 space-y-1" data-testid="category-legend">
-                  {colorState.categories.slice(0, 15).map(entry => (
-                    <div key={entry.name} className="flex items-center text-xs text-gray-700">
-                      <span
-                        className="inline-block w-3 h-3 rounded-sm mr-2 flex-shrink-0"
-                        style={{ backgroundColor: entry.color }}
-                        aria-hidden="true"
-                      />
-                      <span className="truncate" title={entry.name}>{entry.name}</span>
-                    </div>
-                  ))}
-                  {colorState.categories.length > 15 && (
-                    <p className="text-xs text-gray-500">
-                      +{colorState.categories.length - 15} more (colors repeat every 10 categories)
-                    </p>
-                  )}
+                <div className="mt-2" data-testid="category-legend">
+                  {/* Entries are sorted by count, descending — matching the
+                      paint z-order (biggest painted first, rarest on top). */}
+                  <div className="max-h-56 overflow-y-auto space-y-0.5 pr-1">
+                    {colorState.categories.map(entry => (
+                      <button
+                        key={entry.name}
+                        type="button"
+                        onClick={() => onToggleCategory(entry.name)}
+                        aria-pressed={!entry.hidden}
+                        title={entry.hidden ? `Show "${entry.name}"` : `Hide "${entry.name}"`}
+                        className={`w-full flex items-center text-xs rounded px-1 py-0.5 hover:bg-gray-100 transition-colors ${
+                          entry.hidden ? 'text-gray-400 line-through' : 'text-gray-700'
+                        }`}
+                      >
+                        <span
+                          className="inline-block w-3 h-3 rounded-sm mr-2 flex-shrink-0 border"
+                          style={
+                            entry.hidden
+                              ? { backgroundColor: 'transparent', borderColor: entry.color }
+                              : { backgroundColor: entry.color, borderColor: entry.color }
+                          }
+                          aria-hidden="true"
+                        />
+                        <span className="truncate" title={entry.name}>{entry.name}</span>
+                        <span className="ml-auto pl-2 text-gray-500 tabular-nums no-underline">
+                          {entry.count.toLocaleString()}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Click a category to hide/show its points.
+                    {colorState.categories.length > CATEGORY_PALETTE.length &&
+                      ` Colors repeat every ${CATEGORY_PALETTE.length} categories.`}
+                  </p>
                 </div>
               )}
             </div>

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -24,7 +24,7 @@ import {
 } from '../src/utils/webglPoints';
 import { ImageDataLRU, totalSnapshotBytes } from '../src/utils/imageDataCache';
 import { cellValueToNumber } from '../src/utils/cellValueUtils';
-import { MISSING_COLOR, MISSING_SLOT } from '../src/utils/colorUtils';
+import { HIDDEN_SLOT, MISSING_COLOR, MISSING_SLOT, removeHiddenIds } from '../src/utils/colorUtils';
 import type { ColorState } from '../src/utils/colorUtils';
 import { buildRenderKey } from '../src/utils/renderKeyUtils';
 import {
@@ -500,6 +500,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
               paletteKey: colorState.hash,
               palette: glPalette,
               paletteSize: colorState.slotColors.length + 1,
+              // Category slots are count-ranked, so slot-ordered passes
+              // paint big categories first and rare ones on top.
+              zOrderBySlot: colorState.mode === 'category',
             }
             : null,
           filterMode,
@@ -541,6 +544,16 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         // NaN self-compare — store values are finite or NaN by construction.
         if (x !== x || y !== y) continue;
 
+        // slot is undefined when __id is out of slotById's bounds (e.g. a
+        // transient render where colorState lags a data swap); undefined
+        // fails both sentinel checks, so guard it explicitly to avoid
+        // coloredCoords[undefined].push crashing the paint loop.
+        const slot = slotById[rowIds[i]];
+
+        // Toggled-off categories are not painted at all — checked before
+        // the selection branch so hidden points never show up dimmed.
+        if (slot === HIDDEN_SLOT) continue;
+
         if (hasSelection && !selectedFlags[i]) {
           // Unselected points keep the classic dimmed-gray treatment so the
           // selection stays readable even with many colors on screen; in
@@ -549,11 +562,6 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           continue;
         }
 
-        // slot is undefined when __id is out of slotById's bounds (e.g. a
-        // transient render where colorState lags a data swap); undefined
-        // fails both sentinel checks, so guard it explicitly to avoid
-        // coloredCoords[undefined].push crashing the paint loop.
-        const slot = slotById[rowIds[i]];
         const bucket = slot === undefined || slot === MISSING_SLOT || slot >= numSlots
           ? numSlots
           : slot;
@@ -561,6 +569,9 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       }
 
       drawPointBatch(ctx, dimmedCoords, '#ccc', 0.3);
+      // Ascending slot order = descending category size (slots are
+      // count-ranked), so the biggest categories are painted first and
+      // rarer ones stay visible on top.
       const alpha = hasSelection ? 0.8 : 0.7;
       for (let s = 0; s < numSlots; s++) {
         drawPointBatch(ctx, coloredCoords[s], slotColors[s], alpha);
@@ -618,6 +629,16 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
     () => filterData(data, selectedIds, filterMode),
     [data, selectedIds, filterMode]
   );
+
+  // Categories toggled off in the legend are excluded from the row-object
+  // consumers too (stacked histogram bars, regression/correlation fits), so
+  // hiding a category behaves like it isn't on screen. Same reference as
+  // filteredData when nothing is hidden, keeping downstream memos warm.
+  const visibleData = useMemo(() => {
+    if (!colorState?.hasHidden) return filteredData;
+    const { slotById } = colorState;
+    return filteredData.filter(row => slotById[row.__id] !== HIDDEN_SLOT);
+  }, [filteredData, colorState]);
 
   // Memoized per-cell pairwise stats (issues #50/#36): brush-driven repaints
   // in highlight mode reuse the same fit/correlation instead of re-scanning
@@ -1044,7 +1065,8 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         const yVector = columnStore.columns.get(colY.name);
         if (!xVector || !yVector) return;
         const grid = createSpatialGridFromColumns(xVector.values, yVector.values, xScales[i_visible], yScales[j_visible], size);
-        const newSelectedIds = getPointsInBrushFromColumns(grid, xVector.values, yVector.values, columnStore.rowIds, xScales[i_visible], yScales[j_visible], x0, y0, x1, y1, size);
+        // Toggled-off categories are invisible, so they must not be selectable.
+        const newSelectedIds = removeHiddenIds(getPointsInBrushFromColumns(grid, xVector.values, yVector.values, columnStore.rowIds, xScales[i_visible], yScales[j_visible], x0, y0, x1, y1, size), colorState);
         onBrush({ indexX: i_original, indexY: j_original, x0, y0, x1, y1, selectedIds: newSelectedIds });
       });
 
@@ -1271,7 +1293,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           if (!vector) return;
           const minVal = xScales[i_visible].invert(x0);
           const maxVal = xScales[i_visible].invert(x1);
-          const newSelectedIds = selectIdsInValueRange(columnStore, vector, minVal, maxVal);
+          const newSelectedIds = removeHiddenIds(selectIdsInValueRange(columnStore, vector, minVal, maxVal), colorState);
           onBrush({ indexX: i_original, indexY: columns.length, x0, y0: padding / 2, x1, y1: size - padding / 2, selectedIds: newSelectedIds });
         });
 
@@ -1317,7 +1339,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
             : rowBinGenBase.thresholds(thresholds);
           // isFiniteCellValue (not isFinite(+v)): +null === 0, which would
           // bin rows with missing cells as real zeros. See histogramStackUtils.
-          const rowBins = rowBinGen(filteredData.filter(d => isFiniteCellValue(d[column.name])));
+          const rowBins = rowBinGen(visibleData.filter(d => isFiniteCellValue(d[column.name])));
 
           const config = getStackConfig(colorState);
           const { total, selected } = computeStackedBinCounts(rowBins, colorState, config, selectedIds);
@@ -1452,7 +1474,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           if (!vector) return;
           const minVal = yScales[j_visible].invert(y1);
           const maxVal = yScales[j_visible].invert(y0);
-          const newSelectedIds = selectIdsInValueRange(columnStore, vector, minVal, maxVal);
+          const newSelectedIds = removeHiddenIds(selectIdsInValueRange(columnStore, vector, minVal, maxVal), colorState);
           onBrush({ indexX: columns.length, indexY: j_original, x0: padding / 2, y0, x1: size - padding / 2, y1, selectedIds: newSelectedIds });
         });
 
@@ -1496,7 +1518,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
             : rowBinGenBase.thresholds(thresholds);
           // isFiniteCellValue (not isFinite(+v)): +null === 0, which would
           // bin rows with missing cells as real zeros. See histogramStackUtils.
-          const rowBins = rowBinGen(filteredData.filter(d => isFiniteCellValue(d[column.name])));
+          const rowBins = rowBinGen(visibleData.filter(d => isFiniteCellValue(d[column.name])));
 
           const config = getStackConfig(colorState);
           const { total, selected } = computeStackedBinCounts(rowBins, colorState, config, selectedIds);
@@ -1674,7 +1696,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           task.yColName,
           task.xLog,
           task.yLog,
-          filteredData
+          visibleData
         );
         canvasRenderKeyRef.current.set(task.canvasKey, task.renderKey);
         maybeSnapshot(task);
@@ -1710,7 +1732,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (timeoutId !== null) clearTimeout(timeoutId);
     };
-  }, [data, columns, onBrush, filteredData, columnStore, selectedFlags, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, drawReferenceLines, showIdentityLine, showRegressionLine, showCorrelation, tintCellBorders, correlationMetric, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, colorState, onRenderComplete, onRenderProgress]);
+  }, [data, columns, onBrush, visibleData, columnStore, selectedFlags, selectedIds, size, padding, n, showHistograms, useUniformLogBins, filterMode, brushSelection, visibleColumns, visibleIndexToOriginalIndex, renderPointsToCanvas, drawReferenceLines, showIdentityLine, showRegressionLine, showCorrelation, tintCellBorders, correlationMetric, xScales, yScales, cellCoordinates, dataStateHash, selectedStateHash, colorState, onRenderComplete, onRenderProgress]);
 
   return (
     <div

--- a/components/ScatterPlotMatrix.tsx
+++ b/components/ScatterPlotMatrix.tsx
@@ -643,9 +643,16 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
   // Memoized per-cell pairwise stats (issues #50/#36): brush-driven repaints
   // in highlight mode reuse the same fit/correlation instead of re-scanning
   // all rows. Keys fold in everything the stats depend on: column pair,
-  // scale types, data identity, and — in filter mode only, where the fitted
-  // subset changes with the selection — the selection hash.
+  // scale types, data identity, hidden-category state (which changes the
+  // fitted subset), and — in filter mode only, where the fitted subset
+  // changes with the selection — the selection hash.
   const pairStatsCacheRef = useRef<Map<string, PairStats>>(new Map());
+
+  // Key fragment for the hidden-category state: stats are fitted on
+  // visibleData, so toggling a category must not reuse stats cached under a
+  // different visibility state. '-' when nothing is hidden, keeping the
+  // cache warm across color mode/column changes that don't hide rows.
+  const hiddenStatsKey = colorState?.hasHidden ? colorState.hash : '-';
 
   // Reference-line + metrics overlay pass (issues #50/#36): drawn AFTER the
   // point pass onto the same canvas, inside the same paint task, so lines,
@@ -681,6 +688,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
         xLog ? 'log' : 'linear',
         yLog ? 'log' : 'linear',
         dataStateHash,
+        hiddenStatsKey,
         filterMode,
         filterMode === 'filter' ? selectedStateHash : '-',
       ].join('|');
@@ -705,6 +713,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
           yLog ? 'log' : 'linear',
           xLog ? 'log' : 'linear',
           dataStateHash,
+          hiddenStatsKey,
           filterMode,
           filterMode === 'filter' ? selectedStateHash : '-',
         ].join('|');
@@ -820,7 +829,7 @@ export const ScatterPlotMatrix: React.FC<ScatterPlotMatrixProps> = ({
 
     ctx.restore();
     ctx.globalAlpha = 1;
-  }, [showIdentityLine, showRegressionLine, showCorrelation, correlationMetric, tintCellBorders, size, padding, dataStateHash, filterMode, selectedStateHash]);
+  }, [showIdentityLine, showRegressionLine, showCorrelation, correlationMetric, tintCellBorders, size, padding, dataStateHash, hiddenStatsKey, filterMode, selectedStateHash]);
 
   // Scale-domain stats from the columnar store. Full-data stats were already
   // computed during the store's single build pass; only filter mode with an

--- a/src/test/categoryLegend.test.tsx
+++ b/src/test/categoryLegend.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+import { ControlPanel } from '../../components/ControlPanel';
+import { computeColorState } from '../utils/colorUtils';
+import { buildFacetSummaries } from '../utils/facetUtils';
+import type { FacetSelections } from '../utils/facetUtils';
+import type { DataPoint } from '../../types';
+
+// 3 setosa, 2 versicolor, 1 virginica — legend must list them in that order.
+const data: DataPoint[] = [
+  { __id: 0, species: 'virginica', x: 1 },
+  { __id: 1, species: 'setosa', x: 2 },
+  { __id: 2, species: 'versicolor', x: 3 },
+  { __id: 3, species: 'setosa', x: 4 },
+  { __id: 4, species: 'versicolor', x: 5 },
+  { __id: 5, species: 'setosa', x: 6 },
+];
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof ControlPanel>> = {}) {
+  const facetSelections: FacetSelections = new Map();
+  const props: React.ComponentProps<typeof ControlPanel> = {
+    columns: [{ name: 'x', scale: 'linear', visible: true }],
+    visibleDisplayCount: 1,
+    onColumnUpdate: vi.fn(),
+    onDataLoaded: vi.fn(),
+    onLoadFromUrl: vi.fn(),
+    isUrlLoading: false,
+    filterMode: 'highlight',
+    setFilterMode: vi.fn(),
+    showHistograms: false,
+    setShowHistograms: vi.fn(),
+    showDataTable: false,
+    setShowDataTable: vi.fn(),
+    useUniformLogBins: false,
+    setUseUniformLogBins: vi.fn(),
+    globalLogScale: false,
+    onToggleGlobalLogScale: vi.fn(),
+    showIdentityLine: false,
+    setShowIdentityLine: vi.fn(),
+    showRegressionLine: false,
+    setShowRegressionLine: vi.fn(),
+    showCorrelation: false,
+    setShowCorrelation: vi.fn(),
+    tintCellBorders: false,
+    setTintCellBorders: vi.fn(),
+    correlationMetric: 'pearson',
+    setCorrelationMetric: vi.fn(),
+    onSortByCorrelation: vi.fn(),
+    canRestoreColumnOrder: false,
+    onRestoreColumnOrder: vi.fn(),
+    stringColumns: ['species'],
+    columnFilter: '',
+    onColumnFilterChange: vi.fn(),
+    cellSize: 150,
+    onCellSizeChange: vi.fn(),
+    showColumnGroups: false,
+    columnGroups: new Map(),
+    onToggleColumnGroups: vi.fn(),
+    onColumnGroupUpdate: vi.fn(),
+    recentFiles: [],
+    onLoadFromHistory: vi.fn(),
+    onDeleteFromHistory: vi.fn(),
+    onAddPCA: vi.fn(),
+    pcaVariance: null,
+    colorMode: 'category',
+    setColorMode: vi.fn(),
+    categoryColorColumn: 'species',
+    setCategoryColorColumn: vi.fn(),
+    onToggleCategory: vi.fn(),
+    rainbowOrderColumn: null,
+    onResetRainbowOrder: vi.fn(),
+    colorState: computeColorState(data, 'category', 'species', null),
+    facetSummaries: buildFacetSummaries(data, ['species'], facetSelections),
+    facetSelections,
+    activeFacetCount: 0,
+    onToggleFacetValue: vi.fn(),
+    onSetColumnFacet: vi.fn(),
+    onClearAllFacets: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<ControlPanel {...props} />), props };
+}
+
+describe('category legend', () => {
+  it('lists categories sorted by count, descending, with their counts', () => {
+    const { getByTestId } = renderPanel();
+    const legend = getByTestId('category-legend');
+    const buttons = within(legend).getAllByRole('button');
+
+    expect(buttons.map(b => b.textContent)).toEqual([
+      'setosa3',
+      'versicolor2',
+      'virginica1',
+    ]);
+  });
+
+  it('clicking an entry toggles that category', () => {
+    const { getByTestId, props } = renderPanel();
+    const legend = getByTestId('category-legend');
+    fireEvent.click(within(legend).getByRole('button', { name: /virginica/ }));
+    expect(props.onToggleCategory).toHaveBeenCalledWith('virginica');
+  });
+
+  it('marks hidden categories as toggled off', () => {
+    const { getByTestId } = renderPanel({
+      colorState: computeColorState(data, 'category', 'species', null, new Set(['versicolor'])),
+    });
+    const legend = getByTestId('category-legend');
+    const hidden = within(legend).getByRole('button', { name: /versicolor/ });
+    const shown = within(legend).getByRole('button', { name: /setosa/ });
+    expect(hidden.getAttribute('aria-pressed')).toBe('false');
+    expect(shown.getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/src/test/colorUtils.test.ts
+++ b/src/test/colorUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { DataPoint } from '../../types';
 import {
   CATEGORY_PALETTE,
+  HIDDEN_SLOT,
   MISSING_SLOT,
   MISSING_COLOR,
   RAINBOW_BUCKETS,
@@ -10,6 +11,7 @@ import {
   computeRainbowSlots,
   computeColorState,
   computeColorStateHash,
+  removeHiddenIds,
 } from '../utils/colorUtils';
 import { buildRenderKey } from '../utils/renderKeyUtils';
 
@@ -24,14 +26,40 @@ const makeRows = (values: (string | number | null)[], key = 'v'): DataPoint[] =>
   });
 
 describe('computeCategorySlots', () => {
-  it('assigns palette slots by first appearance and maps rows correctly', () => {
+  it('assigns palette slots by count rank (ties by first appearance) and maps rows', () => {
     const data = makeRows(['b', 'a', 'b', 'c', 'a']);
     const { slotById, categories } = computeCategorySlots(data, 'v');
 
+    // b and a tie at 2 rows (b appeared first), c has 1.
     expect(categories.map(c => c.name)).toEqual(['b', 'a', 'c']);
+    expect(categories.map(c => c.count)).toEqual([2, 2, 1]);
     expect(categories[0].color).toBe(CATEGORY_PALETTE[0]);
     expect(categories[1].color).toBe(CATEGORY_PALETTE[1]);
     expect(Array.from(slotById)).toEqual([0, 1, 0, 2, 1]);
+  });
+
+  it('ranks bigger categories into lower slots regardless of appearance order', () => {
+    // 'rare' appears first but has 1 row; 'common' has 3.
+    const data = makeRows(['rare', 'common', 'common', 'common', 'mid', 'mid']);
+    const { slotById, categories } = computeCategorySlots(data, 'v');
+
+    expect(categories.map(c => c.name)).toEqual(['common', 'mid', 'rare']);
+    expect(categories.map(c => c.count)).toEqual([3, 2, 1]);
+    // slot 0 = biggest category -> painted first (bottom of the z-order)
+    expect(slotById[1]).toBe(0);
+    expect(slotById[4]).toBe(1);
+    expect(slotById[0]).toBe(2);
+  });
+
+  it('gives rows of hidden categories the HIDDEN_SLOT sentinel, keeping slots stable', () => {
+    const data = makeRows(['b', 'a', 'b', 'c', 'a']);
+    const { slotById, categories } = computeCategorySlots(data, 'v', new Set(['a']));
+
+    // Hiding does not re-rank: 'a' keeps its legend position, color and count.
+    expect(categories.map(c => c.name)).toEqual(['b', 'a', 'c']);
+    expect(categories.map(c => c.hidden)).toEqual([false, true, false]);
+    expect(categories[1].color).toBe(CATEGORY_PALETTE[1]);
+    expect(Array.from(slotById)).toEqual([0, HIDDEN_SLOT, 0, 2, HIDDEN_SLOT]);
   });
 
   it('marks missing / empty values with the missing sentinel', () => {
@@ -153,6 +181,42 @@ describe('computeColorState', () => {
       computeColorStateHash('rainbow', null, 'depth'),
     ];
     expect(new Set(hashes).size).toBe(hashes.length);
+  });
+
+  it('hash changes when categories are hidden, so cached pixels are invalidated', () => {
+    const none = computeColorStateHash('category', 'species', null);
+    const one = computeColorStateHash('category', 'species', null, new Set(['a']));
+    const two = computeColorStateHash('category', 'species', null, new Set(['a', 'b']));
+    expect(new Set([none, one, two]).size).toBe(3);
+    // Insertion order of the set must not matter.
+    expect(computeColorStateHash('category', 'species', null, new Set(['b', 'a']))).toBe(two);
+  });
+
+  it('exposes hasHidden and hidden legend entries through computeColorState', () => {
+    const data = makeRows(['a', 'b', 'a']);
+    const visible = computeColorState(data, 'category', 'v', null)!;
+    expect(visible.hasHidden).toBe(false);
+
+    const hidden = computeColorState(data, 'category', 'v', null, new Set(['b']))!;
+    expect(hidden.hasHidden).toBe(true);
+    expect(hidden.categories!.find(c => c.name === 'b')!.hidden).toBe(true);
+    expect(hidden.hash).not.toBe(visible.hash);
+  });
+});
+
+describe('removeHiddenIds', () => {
+  it('returns the same set reference when nothing is hidden', () => {
+    const data = makeRows(['a', 'b']);
+    const state = computeColorState(data, 'category', 'v', null);
+    const ids = new Set([0, 1]);
+    expect(removeHiddenIds(ids, state)).toBe(ids);
+    expect(removeHiddenIds(ids, null)).toBe(ids);
+  });
+
+  it('drops rows of hidden categories from a brush hit set', () => {
+    const data = makeRows(['a', 'b', 'a', 'b']);
+    const state = computeColorState(data, 'category', 'v', null, new Set(['b']));
+    expect([...removeHiddenIds(new Set([0, 1, 2, 3]), state)].sort()).toEqual([0, 2]);
   });
 });
 

--- a/src/test/facetPanel.test.tsx
+++ b/src/test/facetPanel.test.tsx
@@ -55,6 +55,7 @@ function renderPanel(overrides: Partial<React.ComponentProps<typeof ControlPanel
     setColorMode: vi.fn(),
     categoryColorColumn: null,
     setCategoryColorColumn: vi.fn(),
+    onToggleCategory: vi.fn(),
     rainbowOrderColumn: null,
     onResetRainbowOrder: vi.fn(),
     colorState: null,

--- a/src/test/stackedHistogram.test.ts
+++ b/src/test/stackedHistogram.test.ts
@@ -45,6 +45,23 @@ describe('getStackConfig', () => {
     expect(config.numStacks).toBe(CATEGORY_PALETTE.length);
     expect(config.stackColors.slice(0, CATEGORY_PALETTE.length)).toEqual([...CATEGORY_PALETTE]);
   });
+
+  it('excludes hidden categories from the bars instead of graying them', () => {
+    const data: DataPoint[] = [
+      { __id: 0, cat: 'a', v: 1 },
+      { __id: 1, cat: 'b', v: 1 },
+      { __id: 2, cat: 'a', v: 2 },
+    ];
+    const state = computeColorState(data, 'category', 'cat', null, new Set(['b']))!;
+    const config = getStackConfig(state);
+    const bins = binRows(data, 'v', 2);
+    const { total } = computeStackedBinCounts(bins, state, config, NO_SELECTION);
+
+    // Only the two 'a' rows are counted; nothing lands in the gray
+    // missing stack.
+    expect(total.flat().reduce((s, c) => s + c, 0)).toBe(2);
+    expect(total.every(stacks => stacks[config.numStacks] === 0)).toBe(true);
+  });
 });
 
 describe('computeStackedBinCounts', () => {

--- a/src/test/webglPoints.test.ts
+++ b/src/test/webglPoints.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../utils/webglPoints';
 import {
   CATEGORY_PALETTE,
+  HIDDEN_SLOT,
   MISSING_SLOT,
   MISSING_COLOR,
   buildRainbowColors,
@@ -67,6 +68,13 @@ describe('buildSlotAttribute', () => {
     const rowIds = new Int32Array([0, 99]); // 99 is out of slotById bounds
     const attr = buildSlotAttribute(slotById, rowIds, 4);
     expect(Array.from(attr)).toEqual([4, 4]); // 7 >= numSlots, undefined -> 4
+  });
+
+  it('maps HIDDEN_SLOT to -1 so the vertex shader culls hidden categories', () => {
+    const slotById = new Uint16Array([1, HIDDEN_SLOT, MISSING_SLOT]);
+    const rowIds = new Int32Array([0, 1, 2]);
+    const attr = buildSlotAttribute(slotById, rowIds, 10);
+    expect(Array.from(attr)).toEqual([1, -1, 10]);
   });
 });
 

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -3,7 +3,9 @@ import type { DataPoint, ColorMode } from '../../types';
 
 // Bump when the palette or gradient assignment scheme changes so cached
 // canvas pixels rendered with the old colors can never be restored.
-export const PALETTE_VERSION = 1;
+// v2: category slots are assigned by count rank (largest category = slot 0)
+// instead of first appearance.
+export const PALETTE_VERSION = 2;
 
 // Colorblind-friendly 10-color categorical palette (Tableau 10).
 // Hard-coded (rather than referencing d3.schemeTableau10) so the palette —
@@ -27,9 +29,19 @@ export const RAINBOW_BUCKETS = 64;
 export const MISSING_SLOT = 0xffff;
 export const MISSING_COLOR = '#9ca3af';
 
+// Sentinel slot for rows whose category has been toggled off in the legend.
+// Distinct from MISSING_SLOT: hidden rows are not painted at all (and are
+// excluded from brush hits and stacked histograms), whereas missing rows
+// stay visible in neutral gray.
+export const HIDDEN_SLOT = 0xfffe;
+
 export interface CategoryLegendEntry {
   name: string;
   color: string;
+  /** Rows carrying this category value (over the full dataset). */
+  count: number;
+  /** True when the category is toggled off via the legend. */
+  hidden: boolean;
 }
 
 export interface ColorState {
@@ -41,8 +53,10 @@ export interface ColorState {
   slotById: Uint16Array;
   /** Fill color per slot (10 palette colors or RAINBOW_BUCKETS viridis steps). */
   slotColors: string[];
-  /** Legend entries (category mode only). */
+  /** Legend entries, sorted by count descending (category mode only). */
   categories: CategoryLegendEntry[] | null;
+  /** True when at least one category is toggled off (HIDDEN_SLOT in use). */
+  hasHidden: boolean;
   /** Rainbow mode: column whose rank drives the gradient; null = file order. */
   orderColumn: string | null;
   /**
@@ -60,36 +74,51 @@ export function buildRainbowColors(buckets: number = RAINBOW_BUCKETS): string[] 
 
 /**
  * Category color slots: each row gets the palette slot of its category.
- * Categories are discovered in order of first appearance; the palette
- * cycles for datasets with more than CATEGORY_PALETTE.length categories
- * (slot = categoryIndex % palette size), so two categories may share a
- * color but the paint loop stays bounded at 10 fill batches per cell.
- * Rows whose value is missing/empty get MISSING_SLOT.
+ * Categories are ranked by row count, descending (ties broken by first
+ * appearance), and slot = rank % palette size. Ranking by size means the
+ * paint loops — which draw slot 0 first — put the biggest categories at
+ * the bottom of the z-order, so rarer categories stay visible on top.
+ * The palette cycles for datasets with more than CATEGORY_PALETTE.length
+ * categories, so two categories may share a color but the paint loop stays
+ * bounded at 10 fill batches per cell.
+ * Rows whose value is missing/empty get MISSING_SLOT; rows whose category
+ * is in `hiddenCategories` get HIDDEN_SLOT (not painted at all).
  */
 export function computeCategorySlots(
   data: DataPoint[],
-  columnName: string
+  columnName: string,
+  hiddenCategories: ReadonlySet<string> = new Set()
 ): { slotById: Uint16Array; categories: CategoryLegendEntry[] } {
   const slotById = new Uint16Array(data.length).fill(MISSING_SLOT);
-  const categoryIndex = new Map<string, number>();
-  const categories: CategoryLegendEntry[] = [];
 
+  // Pass 1: count rows per category value (Map preserves first appearance).
+  const counts = new Map<string, number>();
   for (const row of data) {
     const raw = row[columnName];
     if (raw === undefined || raw === null || raw === '') continue;
     const value = String(raw);
-    let idx = categoryIndex.get(value);
-    if (idx === undefined) {
-      idx = categories.length;
-      categoryIndex.set(value, idx);
-      categories.push({
-        name: value,
-        color: CATEGORY_PALETTE[idx % CATEGORY_PALETTE.length],
-      });
-    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  // Rank by count descending; Array.sort is stable, so equal counts keep
+  // first-appearance order.
+  const ranked = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+
+  const slotByValue = new Map<string, number>();
+  const categories: CategoryLegendEntry[] = ranked.map(([name, count], rank) => {
+    const hidden = hiddenCategories.has(name);
+    const slot = rank % CATEGORY_PALETTE.length;
+    slotByValue.set(name, hidden ? HIDDEN_SLOT : slot);
+    return { name, color: CATEGORY_PALETTE[slot], count, hidden };
+  });
+
+  // Pass 2: assign each row its category's slot.
+  for (const row of data) {
+    const raw = row[columnName];
+    if (raw === undefined || raw === null || raw === '') continue;
     const id = row.__id;
     if (id >= 0 && id < slotById.length) {
-      slotById[id] = idx % CATEGORY_PALETTE.length;
+      slotById[id] = slotByValue.get(String(raw))!;
     }
   }
 
@@ -159,12 +188,18 @@ export function computeRainbowSlots(
 export function computeColorStateHash(
   mode: ColorMode,
   categoryColumn: string | null,
-  orderColumn: string | null
+  orderColumn: string | null,
+  hiddenCategories: ReadonlySet<string> = new Set()
 ): string {
   if (mode === 'none') return 'none';
+  // Hidden categories change which points are painted, so they must
+  // invalidate cached pixels; sorted for a stable key.
+  const hidden = mode === 'category' && hiddenCategories.size > 0
+    ? `:hid[${[...hiddenCategories].sort().join('\u0001')}]`
+    : '';
   return `${mode}:${mode === 'category' ? categoryColumn ?? '' : ''}:${
     mode === 'rainbow' ? orderColumn ?? '' : ''
-  }:p${PALETTE_VERSION}`;
+  }:p${PALETTE_VERSION}${hidden}`;
 }
 
 /**
@@ -177,20 +212,22 @@ export function computeColorState(
   data: DataPoint[],
   mode: ColorMode,
   categoryColumn: string | null,
-  orderColumn: string | null
+  orderColumn: string | null,
+  hiddenCategories: ReadonlySet<string> = new Set()
 ): ColorState | null {
   if (mode === 'none' || data.length === 0) return null;
 
   if (mode === 'category') {
     if (!categoryColumn) return null;
-    const { slotById, categories } = computeCategorySlots(data, categoryColumn);
+    const { slotById, categories } = computeCategorySlots(data, categoryColumn, hiddenCategories);
     return {
       mode,
       slotById,
       slotColors: CATEGORY_PALETTE.slice(),
       categories,
+      hasHidden: categories.some(c => c.hidden),
       orderColumn: null,
-      hash: computeColorStateHash(mode, categoryColumn, null),
+      hash: computeColorStateHash(mode, categoryColumn, null, hiddenCategories),
     };
   }
 
@@ -199,7 +236,26 @@ export function computeColorState(
     slotById: computeRainbowSlots(data, orderColumn),
     slotColors: buildRainbowColors(),
     categories: null,
+    hasHidden: false,
     orderColumn,
     hash: computeColorStateHash(mode, null, orderColumn),
   };
+}
+
+/**
+ * Drop rows of hidden categories from a brush hit set, so toggled-off
+ * points cannot be selected invisibly. Returns the input set unchanged
+ * (same reference) when nothing is hidden.
+ */
+export function removeHiddenIds(
+  ids: Set<number>,
+  colorState: ColorState | null
+): Set<number> {
+  if (!colorState?.hasHidden || ids.size === 0) return ids;
+  const { slotById } = colorState;
+  const out = new Set<number>();
+  for (const id of ids) {
+    if (slotById[id] !== HIDDEN_SLOT) out.add(id);
+  }
+  return out;
 }

--- a/src/utils/histogramStackUtils.ts
+++ b/src/utils/histogramStackUtils.ts
@@ -1,7 +1,7 @@
 import { interpolateViridis } from 'd3';
 import type { DataPoint } from '../../types';
 import type { ColorState } from './colorUtils';
-import { CATEGORY_PALETTE, MISSING_COLOR, MISSING_SLOT, RAINBOW_BUCKETS } from './colorUtils';
+import { CATEGORY_PALETTE, HIDDEN_SLOT, MISSING_COLOR, MISSING_SLOT, RAINBOW_BUCKETS } from './colorUtils';
 
 // Issue #40: with a color mode active, histogram bars become stacked bars —
 // one segment per color group per bin. The continuous rainbow gradient is
@@ -20,7 +20,10 @@ export interface StackConfig {
   numStacks: number;
   /** One color per stack, plus MISSING_COLOR at index numStacks. */
   stackColors: string[];
-  /** Maps a ColorState slot to a stack index (MISSING_SLOT -> numStacks). */
+  /**
+   * Maps a ColorState slot to a stack index (MISSING_SLOT -> numStacks;
+   * HIDDEN_SLOT -> -1, meaning the row is excluded from the bar entirely).
+   */
   stackSlotFor: (slot: number) => number;
 }
 
@@ -30,8 +33,12 @@ export function getStackConfig(colorState: ColorState): StackConfig {
     return {
       numStacks,
       stackColors: [...CATEGORY_PALETTE, MISSING_COLOR],
+      // HIDDEN_SLOT must be checked before the >= numStacks catch-all,
+      // otherwise hidden rows would land in the gray missing stack.
       stackSlotFor: (slot: number) =>
-        slot === MISSING_SLOT || slot >= numStacks ? numStacks : slot,
+        slot === HIDDEN_SLOT
+          ? -1
+          : slot === MISSING_SLOT || slot >= numStacks ? numStacks : slot,
     };
   }
 
@@ -78,6 +85,7 @@ export function computeStackedBinCounts(
       const id = row.__id;
       const slot = id >= 0 && id < slotById.length ? slotById[id] : MISSING_SLOT;
       const stack = config.stackSlotFor(slot);
+      if (stack < 0) continue; // hidden category — excluded from the bar
       total[binIndex][stack]++;
       if (hasSelection && selectedIds.has(id)) {
         selected[binIndex][stack]++;

--- a/src/utils/webglPoints.ts
+++ b/src/utils/webglPoints.ts
@@ -1,6 +1,7 @@
 /**
  * Minimal hand-rolled WebGL1 point-sprite renderer for the scatter matrix
- * (issue #33). No dependencies.
+ * (issue #33). No external dependencies (only the HIDDEN_SLOT sentinel
+ * from colorUtils).
  *
  * Architecture — "render one cell, blit into its 2D canvas":
  *
@@ -44,6 +45,8 @@
  *   approximate Canvas 2D's antialiased arcs.
  */
 
+import { HIDDEN_SLOT } from './colorUtils';
+
 /** Sentinel t for missing values; the vertex shader culls anything ≤ -9. */
 export const MISSING_T = -10;
 
@@ -73,8 +76,9 @@ void main() {
   vSlot = aSlot;
   vFlag = aFlag;
   gl_PointSize = uPointSize;
-  if (aX <= -9.0 || aY <= -9.0) {
-    // Missing value: outside the clip volume -> the point is culled.
+  if (aX <= -9.0 || aY <= -9.0 || aSlot < -0.5) {
+    // Missing value or hidden category (slot -1): outside the clip
+    // volume -> the point is culled.
     gl_Position = vec4(0.0, 0.0, 2.0, 1.0);
     return;
   }
@@ -96,9 +100,11 @@ uniform sampler2D uPalette;
 uniform float uPaletteSize;
 uniform float uPointRadius;
 uniform float uPointSize;
+uniform float uSlotFilter;  // >= 0: draw only points of this slot (z-order passes)
 void main() {
   if (uPass < 0.5 && vFlag > 0.5) discard;
   if (uPass > 0.5 && uPass < 1.5 && vFlag < 0.5) discard;
+  if (uSlotFilter > -0.5 && abs(vSlot - uSlotFilter) > 0.25) discard;
   vec2 c = (gl_PointCoord - 0.5) * uPointSize;
   float dist = length(c);
   float mask = 1.0 - smoothstep(uPointRadius - 1.0, uPointRadius, dist);
@@ -158,7 +164,8 @@ export function buildNormalizedPositions(
  * Per-point palette slot attribute from ColorState.slotById (indexed by
  * __id) via the store's rowIds. Bucket rules mirror the 2D paint loop:
  * MISSING_SLOT, out-of-palette and out-of-bounds ids all land in the last
- * texel (the missing color).
+ * texel (the missing color); HIDDEN_SLOT becomes -1, which the vertex
+ * shader culls entirely.
  */
 export function buildSlotAttribute(
   slotById: Uint16Array,
@@ -168,7 +175,9 @@ export function buildSlotAttribute(
   const out = new Float32Array(rowIds.length);
   for (let i = 0; i < rowIds.length; i++) {
     const slot = slotById[rowIds[i]]; // undefined when __id out of bounds
-    out[i] = slot === undefined || slot >= numSlots ? numSlots : slot;
+    out[i] = slot === HIDDEN_SLOT
+      ? -1
+      : slot === undefined || slot >= numSlots ? numSlots : slot;
   }
   return out;
 }
@@ -264,6 +273,13 @@ export interface CellRenderOptions {
     palette: Uint8Array;
     /** Texel count == palette.length / 4. */
     paletteSize: number;
+    /**
+     * Category mode: draw one pass per slot, slot 0 first, so bigger
+     * categories (lower slots by construction) sit beneath rarer ones —
+     * matching the 2D path's batched-by-slot paint order. Off for rainbow
+     * (64 passes for an order that follows the gradient anyway).
+     */
+    zOrderBySlot?: boolean;
   } | null;
   filterMode: 'highlight' | 'filter';
 }
@@ -351,6 +367,7 @@ export class WebGLPointRenderer {
       [
         'uXRange', 'uYRange', 'uCanvasSize', 'uPointSize', 'uPass',
         'uUseTexture', 'uColor', 'uPalette', 'uPaletteSize', 'uPointRadius',
+        'uSlotFilter',
       ].map(name => [name, gl.getUniformLocation(program, name)])
     );
 
@@ -424,9 +441,9 @@ export class WebGLPointRenderer {
 
     const hasSelection = opts.flags !== null;
     if (!hasSelection) {
-      // Single pass over every point.
+      // Single pass over every point (per-slot passes in category mode).
       if (opts.color) {
-        this.draw(2, true, [0, 0, 0, 0.7], opts.count);
+        this.drawColored(2, 0.7, opts);
       } else {
         this.draw(2, false, colorToVec4('#4b5563', 0.7), opts.count);
       }
@@ -439,11 +456,28 @@ export class WebGLPointRenderer {
       this.draw(0, false, colorToVec4('#ccc', 0.3), opts.count);
     }
     if (opts.color) {
-      this.draw(1, true, [0, 0, 0, 0.8], opts.count);
+      this.drawColored(1, 0.8, opts);
     } else {
       this.draw(1, false, colorToVec4('#1e40af', 0.8), opts.count);
     }
     return true;
+  }
+
+  /**
+   * Textured (palette-colored) draw. With zOrderBySlot, one pass per
+   * palette texel in ascending slot order — slots are count-ranked in
+   * category mode, so the biggest categories are painted first and rare
+   * ones land on top (the missing-color texel last, like the 2D path).
+   */
+  private drawColored(pass: number, alpha: number, opts: CellRenderOptions): void {
+    const color = opts.color!;
+    if (!color.zOrderBySlot) {
+      this.draw(pass, true, [0, 0, 0, alpha], opts.count);
+      return;
+    }
+    for (let slot = 0; slot < color.paletteSize; slot++) {
+      this.draw(pass, true, [0, 0, 0, alpha], opts.count, slot);
+    }
   }
 
   dispose(): void {
@@ -466,11 +500,13 @@ export class WebGLPointRenderer {
     pass: number,
     useTexture: boolean,
     rgba: [number, number, number, number],
-    count: number
+    count: number,
+    slotFilter: number = -1
   ): void {
     const { gl } = this;
     gl.uniform1f(this.uniforms.uPass, pass);
     gl.uniform1f(this.uniforms.uUseTexture, useTexture ? 1 : 0);
+    gl.uniform1f(this.uniforms.uSlotFilter, slotFilter);
     gl.uniform4f(this.uniforms.uColor, rgba[0], rgba[1], rgba[2], rgba[3]);
     gl.drawArrays(gl.POINTS, 0, count);
   }


### PR DESCRIPTION
## Summary

Category color mode gets the legend/painting behavior discussed:

- **Counts in the legend** — each category shows its row count (thousands-separated), and entries are **sorted by count, descending** (ties broken by first appearance).
- **Z-order biggest-first** — palette slots are now assigned by count rank (largest category = slot 0) instead of first appearance. The Canvas 2D path already paints slots in ascending order; the WebGL path gains per-slot draw passes (`uSlotFilter` uniform) to match. Big categories are painted first, so rare categories stay visible on top. `PALETTE_VERSION` bumped to 2 (assignment scheme changed).
- **Click a category to toggle it off/on** — hidden rows get a `HIDDEN_SLOT` sentinel and are consistently gone: not painted on either backend, excluded from stacked histogram bars, regression/correlation fits, and brush hits; hiding a category also prunes its rows from a live selection. Hiding never re-ranks colors, so remaining categories keep their hues. Hidden state resets on column switch or data load, and is folded into the color-state hash so cached canvas pixels / GPU buffers invalidate correctly.
- Legend list is scrollable for >10 categories, with a note that colors repeat.

Also adds a project `verify` skill (`.claude/skills/verify/SKILL.md`) documenting the build/launch/drive recipe used to verify this.

## Testing

- 326 tests pass (11 new: count-ranked slots, hidden sentinels, hash invalidation, brush stripping, stacked-bar exclusion, legend UI). Typecheck clean.
- Verified end-to-end in Chrome (WebGL backend) against a 6,155-row / 12-category skewed dataset: counts + sorting in legend, rare 5-point category visible atop a 3,000-point cloud, hide/show round-trip updates points + stacked histograms, brush with a hidden category selects 0 hidden rows, hiding mid-selection prunes 6,092 → 3,147, rainbow mode unaffected, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive category legend to toggle categories on/off in color-based views.
  * Added end-to-end browser verification guidance for real-browser testing of app changes.
* **Bug Fixes**
  * Hidden categories are now excluded from plot rendering, brush selection, histogram binning/stacking, and reference-line statistics.
  * Updated rendering so WebGL correctly culls hidden-category points and stays in sync with overlays.
* **Tests**
  * Added/expanded unit and UI tests covering legend toggling, hidden-category coloring, and stacked histogram behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->